### PR TITLE
Fix clippy non-snake-case warning for Binance agg trade timestamp

### DIFF
--- a/src/binance.rs
+++ b/src/binance.rs
@@ -10,7 +10,8 @@ pub struct AggTrade {
     pub s: String,
     pub p: String,
     pub q: String,
-    pub T: u64,
+    #[serde(rename = "T")]
+    pub t: u64,
     pub m: bool,
 }
 
@@ -41,9 +42,9 @@ pub async fn log_and_broadcast(
     let qty: f64 = agg.q.parse().unwrap_or(0.0);
 
     if qty >= cfg.big_trade_qty || spike >= cfg.spike_pct {
-        let dt_utc7 = utc_to_utc7(agg.T as i64);
+        let dt_utc7 = utc_to_utc7(agg.t as i64);
         let ts_str = format_ts(dt_utc7);
-        let delay_ms = Utc::now().timestamp_millis() - agg.T as i64;
+        let delay_ms = Utc::now().timestamp_millis() - agg.t as i64;
 
         let log_msg = format!(
             "[{}] {} - Price: {:.2}, Qty: {:.4}, Spike: {:.4}%, BuyerMaker: {}, Delay: {} ms",


### PR DESCRIPTION
### Motivation
- Resolve clippy’s `non_snake_case` lint triggered by the `AggTrade` timestamp field while keeping binary/JSON compatibility with Binance payloads.

### Description
- Rename struct field from `T` to `t` and add `#[serde(rename = "T")]` so incoming JSON with `"T"` still deserializes correctly.
- Update `log_and_broadcast` to use `agg.t` for UTC conversion and delay calculation.

### Testing
- Ran `cargo clippy --all-targets --all-features -D warnings`, but it failed due to the environment being unable to sync the Rust toolchain from `static.rust-lang.org` (network/toolchain error).
- Ran `RUSTUP_TOOLCHAIN=stable cargo check --all-targets --offline`, which also failed for the same rustup sync/network limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4361c224832dbae96ecbbb634e6d)