### PR TITLE
Fix AggTrade timestamp field naming in binance parser

### DIFF
--- a/src/binance.rs
+++ b/src/binance.rs
@@ -10,7 +10,8 @@ pub struct AggTrade {
     pub s: String,
     pub p: String,
     pub q: String,
-    pub T: u64,
+    #[serde(rename = "T")]
+    pub t: u64,
     pub m: bool,
 }
 
@@ -39,9 +40,9 @@ pub async fn log_and_broadcast(
     let qty: f64 = agg.q.parse().unwrap_or(0.0);
 
     if qty >= cfg.big_trade_qty || spike >= cfg.spike_pct {
-        let dt_utc7 = utc_to_utc7(agg.T as i64);
+        let dt_utc7 = utc_to_utc7(agg.t as i64);
         let ts_str = format_ts(dt_utc7);
-        let delay_ms = Utc::now().timestamp_millis() - agg.T as i64;
+        let delay_ms = Utc::now().timestamp_millis() - agg.t as i64;
 
         let log_msg = format!(
             "[{}] {} - Price: {:.2}, Qty: {:.4}, Spike: {:.4}%, BuyerMaker: {}, Delay: {} ms",


### PR DESCRIPTION
### Motivation
- Resolve a field-name mismatch and compilation error by making the Binance `AggTrade` timestamp use an idiomatic Rust name while preserving JSON compatibility.

### Description
- In `src/binance.rs` rename `pub T: u64` to `pub t: u64` and add `#[serde(rename = "T")]` so incoming JSON still deserializes correctly.
- Update timestamp usages in `log_and_broadcast` to reference `agg.t` for UTC+7 conversion and delay calculation.

### Testing
- Ran `cargo test --all -- --nocapture`, which completed successfully with tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4495a810832d90f5a43dbc3d0a8f)