### PR TITLE
Improve JSON parse error visibility and optional unknown-message logging

### DIFF
--- a/src/json_helpers.rs
+++ b/src/json_helpers.rs
@@ -7,6 +7,20 @@ pub fn parse_combined_data<T>(msg: &str) -> Option<T>
 where
     T: serde::de::DeserializeOwned,
 {
-    let wrapper: CombinedStreamMsg<T> = serde_json::from_str(msg).ok()?;
+    let wrapper: CombinedStreamMsg<T> = match serde_json::from_str(msg) {
+        Ok(wrapper) => wrapper,
+        Err(err) => {
+            let snippet: String = msg.chars().take(180).collect();
+            let suffix = if msg.chars().count() > 180 { "..." } else { "" };
+            eprintln!(
+                "[parse_combined_data:{}] invalid JSON: {} payload='{}{}'",
+                std::any::type_name::<T>(),
+                err,
+                snippet,
+                suffix
+            );
+            return None;
+        }
+    };
     Some(wrapper.data)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,17 @@ async fn main() {
                 );
                 println!("{}", depth_msg);
                 let _ = tx.send(depth_msg);
+                continue;
+            }
+
+            if std::env::var_os("LOG_UNKNOWN_STREAM_MESSAGES").is_some() {
+                let snippet: String = payload.chars().take(180).collect();
+                let suffix = if payload.chars().count() > 180 {
+                    "..."
+                } else {
+                    ""
+                };
+                eprintln!("[stream] unhandled text message: '{}{}'", snippet, suffix);
             }
         }
     }


### PR DESCRIPTION
### Motivation

- Make JSON parse failures visible for easier debugging while preserving the existing `Option`-based control flow.  
- Ensure unexpected/unknown WebSocket text messages can be observed in production logs when desired.  

### Description

- Replaced the silent `serde_json::from_str(msg).ok()?` in `parse_combined_data` with a `match` that logs parse errors and a truncated payload snippet and then returns `None` to preserve previous flow; the log includes the parser target type via `std::any::type_name::<T>()` and truncates the payload to 180 characters.  
- Added an explicit `continue` after depth handling in the stream loop to keep control flow clear.  
- Added an optional fallback branch in `main.rs` that logs non-`aggTrade`/non-`depth` text stream messages to stderr when the `LOG_UNKNOWN_STREAM_MESSAGES` environment variable is set, also truncating the payload to 180 characters.  

### Testing

- Ran `cargo fmt && cargo test`, but the run failed due to an environment network/tunnel issue while attempting to download Rust toolchain metadata; no unit test failures were observed locally because the toolchain download prevented test execution.  
- No automated test files were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b61917d08832dbdc770ad0ac3148b)