### PR TITLE
Fix DEPTH log format placeholders in main stream formatter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ async fn main() {
                 };
 
                 let depth_msg = format!(
-                    "[DEPTH] {} E:{} U:{} u:{} big_bids:[{}] big_asks:[{}]",
+                    "[DEPTH] {} bids:[{}] asks:[{}] E:{} U:{} u:{} big_bids:[{}] big_asks:[{}]",
                     depth.symbol.to_uppercase(),
                     format_depth_levels(&matched_bids),
                     format_depth_levels(&matched_asks),


### PR DESCRIPTION
## Summary
- fixed the `[DEPTH]` message format string in `src/main.rs` to include placeholders for both formatted bid and ask depth levels
- this aligns the format string with the provided arguments and resolves the `multiple unused formatting arguments` clippy/build error

## Validation
- attempted to run `cargo clippy --all-targets --all-features -- -D warnings`
- clippy execution was blocked by rustup failing to download channel metadata in this environment (`unsuccessful tunnel`)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7e1a3260832d9c9e72b169a9e756)