### PR TITLE
Add configurable pressure filter for depth events

### DIFF
--- a/src/binance_depth.rs
+++ b/src/binance_depth.rs
@@ -63,6 +63,15 @@ pub fn is_big_depth_update(bids: &[ParsedDepthLevel], asks: &[ParsedDepthLevel])
     !bids.is_empty() || !asks.is_empty()
 }
 
+pub fn passes_pressure_filter(bid_pressure_pct: f64, min_pressure_pct: f64) -> bool {
+    if min_pressure_pct <= 0.0 {
+        return true;
+    }
+
+    let threshold = min_pressure_pct.clamp(0.0, 100.0);
+    bid_pressure_pct >= threshold || bid_pressure_pct <= (100.0 - threshold)
+}
+
 pub fn format_depth_levels(levels: &[ParsedDepthLevel]) -> String {
     if levels.is_empty() {
         return "-".to_string();

--- a/src/binance_depth_tests.rs
+++ b/src/binance_depth_tests.rs
@@ -72,6 +72,18 @@ fn is_big_depth_update_requires_any_side_match() {
 }
 
 #[test]
+fn passes_pressure_filter_accepts_balanced_when_disabled() {
+    assert!(passes_pressure_filter(50.0, 0.0));
+}
+
+#[test]
+fn passes_pressure_filter_requires_directional_imbalance() {
+    assert!(!passes_pressure_filter(52.0, 60.0));
+    assert!(passes_pressure_filter(70.0, 60.0));
+    assert!(passes_pressure_filter(35.0, 60.0));
+}
+
+#[test]
 fn format_depth_levels_uses_compact_representation() {
     let levels = vec![
         ParsedDepthLevel {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub broadcast_capacity: usize,
     pub big_depth_min_qty: f64,
     pub big_depth_min_notional: f64,
+    pub big_depth_min_pressure_pct: f64,
 }
 
 impl Config {
@@ -69,12 +70,18 @@ impl Config {
             .and_then(|v| v.parse::<f64>().ok())
             .unwrap_or(0.0);
 
+        let big_depth_min_pressure_pct = env::var("BIG_DEPTH_MIN_PRESSURE_PCT")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .unwrap_or(0.0);
+
         Config {
             symbols,
             port,
             broadcast_capacity,
             big_depth_min_qty,
             big_depth_min_notional,
+            big_depth_min_pressure_pct,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ async fn main() {
         ip_display, config.port
     );
     println!(
-        "Depth filters => min_qty: {}, min_notional: {}",
-        config.big_depth_min_qty, config.big_depth_min_notional
+        "Depth filters => min_qty: {}, min_notional: {}, min_pressure: {}",
+        config.big_depth_min_qty, config.big_depth_min_notional, config.big_depth_min_pressure_pct
     );
     tokio::spawn(warp::serve(ws_route).run(([0, 0, 0, 0], config.port)));
 
@@ -190,6 +190,10 @@ async fn main() {
                 } else {
                     0.0
                 };
+
+                if !passes_pressure_filter(bid_pressure_pct, config.big_depth_min_pressure_pct) {
+                    continue;
+                }
 
                 let depth_msg = format!(
                     "[DEPTH] {} bids:[{}] asks:[{}] pressure:{:.1}%bid E:{} U:{} u:{} big_bids<{}> big_asks<{}>",


### PR DESCRIPTION
## Summary
- add a new `BIG_DEPTH_MIN_PRESSURE_PCT` config value to control directional depth imbalance filtering
- implement `passes_pressure_filter` in `src/binance_depth.rs` and cover it with unit tests
- apply the pressure filter in the depth event pipeline in `src/main.rs` before broadcasting
- include the pressure threshold in startup logging for observability

## Testing
- `cargo test` *(fails in this environment because rustup cannot download toolchain metadata: unsuccessful tunnel to static.rust-lang.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b84c313e8832d93cc13a6b365756a)