### PR TITLE
Handle negative pressure values in depth filter

### DIFF
--- a/src/binance_depth.rs
+++ b/src/binance_depth.rs
@@ -69,7 +69,9 @@ pub fn passes_pressure_filter(bid_pressure_pct: f64, min_pressure_pct: f64) -> b
     }
 
     let threshold = min_pressure_pct.clamp(0.0, 100.0);
-    bid_pressure_pct >= threshold || bid_pressure_pct <= (100.0 - threshold)
+    let normalized_bid_pressure = bid_pressure_pct.abs().clamp(0.0, 100.0);
+
+    normalized_bid_pressure >= threshold || normalized_bid_pressure <= (100.0 - threshold)
 }
 
 pub fn format_depth_levels(levels: &[ParsedDepthLevel]) -> String {

--- a/src/binance_depth_tests.rs
+++ b/src/binance_depth_tests.rs
@@ -84,6 +84,12 @@ fn passes_pressure_filter_requires_directional_imbalance() {
 }
 
 #[test]
+fn passes_pressure_filter_handles_negative_pressure_values() {
+    assert!(passes_pressure_filter(-70.0, 60.0));
+    assert!(!passes_pressure_filter(-52.0, 60.0));
+}
+
+#[test]
 fn format_depth_levels_uses_compact_representation() {
     let levels = vec![
         ParsedDepthLevel {


### PR DESCRIPTION
### Motivation
- Depth pressure can be reported as a negative value, and comparisons should treat the magnitude (absolute value) rather than sign when applying the configured threshold.
- Ensuring consistent behavior for negative pressures prevents valid imbalance detections from being skipped or misclassified.

### Description
- Update `passes_pressure_filter` in `src/binance_depth.rs` to normalize `bid_pressure_pct` with `abs()` and `clamp(0.0, 100.0)` before applying the threshold comparison so negative values are handled consistently.
- Add `passes_pressure_filter_handles_negative_pressure_values` unit test in `src/binance_depth_tests.rs` to verify that large negative pressures pass and smaller negative pressures fail relative to a threshold.

### Testing
- Attempted to run `cargo test` in the environment, but the run failed due to a rustup network/download error (`channel-rust-stable.toml.sha256` download failed), so tests could not be executed here.
- New unit test added to the test suite; it should run successfully in a normal CI environment when `cargo test` can complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b88cb0a2c832d8f27a952fb81e234)