### PR TITLE
Refine AGG_TRADE output and depth pressure filtering

### DIFF
--- a/src/binance.rs
+++ b/src/binance.rs
@@ -1,7 +1,6 @@
 // File: src/binance.rs
 use crate::config::SymbolConfig;
 use crate::json_helpers::parse_combined_data;
-use crate::time_helpers::{format_ts, utc_to_utc7};
 use chrono::Utc;
 use tokio::sync::broadcast;
 
@@ -35,13 +34,10 @@ pub async fn log_and_broadcast(
     let qty: f64 = agg.q.parse().unwrap_or(0.0);
 
     if qty >= cfg.big_trade_qty || spike >= cfg.spike_pct {
-        let dt_utc7 = utc_to_utc7(agg.t as i64);
-        let ts_str = format_ts(dt_utc7);
         let delay_ms = Utc::now().timestamp_millis() - agg.t as i64;
 
         let log_msg = format!(
-            "[{}] {} - Price: {:.2}, Qty: {:.4}, Spike: {:.4}%, BuyerMaker: {}, Delay: {} ms",
-            ts_str,
+            "[AGG_TRADE] {} - Price: {:.2}, Qty: {:.4}, Spike: {:.4}%, BuyerMaker: {}, Delay: {} ms",
             agg.s.to_uppercase(),
             price,
             qty,

--- a/src/binance_depth.rs
+++ b/src/binance_depth.rs
@@ -63,15 +63,20 @@ pub fn is_big_depth_update(bids: &[ParsedDepthLevel], asks: &[ParsedDepthLevel])
     !bids.is_empty() || !asks.is_empty()
 }
 
-pub fn passes_pressure_filter(bid_pressure_pct: f64, min_pressure_pct: f64) -> bool {
+pub fn passes_pressure_filter(
+    bid_pressure_pct: f64,
+    sell_pressure_pct: f64,
+    min_pressure_pct: f64,
+) -> bool {
     if min_pressure_pct <= 0.0 {
         return true;
     }
 
     let threshold = min_pressure_pct.clamp(0.0, 100.0);
-    let normalized_bid_pressure = bid_pressure_pct.abs().clamp(0.0, 100.0);
+    let bid_pressure = bid_pressure_pct.clamp(0.0, 100.0);
+    let sell_pressure = sell_pressure_pct.clamp(0.0, 100.0);
 
-    normalized_bid_pressure >= threshold || normalized_bid_pressure <= (100.0 - threshold)
+    bid_pressure >= threshold || sell_pressure >= threshold
 }
 
 pub fn format_depth_levels(levels: &[ParsedDepthLevel]) -> String {

--- a/src/binance_depth_tests.rs
+++ b/src/binance_depth_tests.rs
@@ -73,20 +73,20 @@ fn is_big_depth_update_requires_any_side_match() {
 
 #[test]
 fn passes_pressure_filter_accepts_balanced_when_disabled() {
-    assert!(passes_pressure_filter(50.0, 0.0));
+    assert!(passes_pressure_filter(50.0, 50.0, 0.0));
 }
 
 #[test]
 fn passes_pressure_filter_requires_directional_imbalance() {
-    assert!(!passes_pressure_filter(52.0, 60.0));
-    assert!(passes_pressure_filter(70.0, 60.0));
-    assert!(passes_pressure_filter(35.0, 60.0));
+    assert!(!passes_pressure_filter(52.0, 48.0, 60.0));
+    assert!(passes_pressure_filter(70.0, 30.0, 60.0));
+    assert!(passes_pressure_filter(35.0, 65.0, 60.0));
 }
 
 #[test]
-fn passes_pressure_filter_handles_negative_pressure_values() {
-    assert!(passes_pressure_filter(-70.0, 60.0));
-    assert!(!passes_pressure_filter(-52.0, 60.0));
+fn passes_pressure_filter_clamps_out_of_range_values() {
+    assert!(passes_pressure_filter(120.0, -20.0, 60.0));
+    assert!(!passes_pressure_filter(-10.0, -5.0, 60.0));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,9 +189,21 @@ async fn main() {
                     (bid_total_notional / total_notional) * 100.0
                 } else {
                     0.0
+                }
+                .clamp(0.0, 100.0);
+                let sell_pressure_pct = (100.0 - bid_pressure_pct).clamp(0.0, 100.0);
+
+                let bid_pressure_pct = if bid_pressure_pct == 0.0 {
+                    0.0
+                } else {
+                    bid_pressure_pct
                 };
 
-                if !passes_pressure_filter(bid_pressure_pct, config.big_depth_min_pressure_pct) {
+                if !passes_pressure_filter(
+                    bid_pressure_pct,
+                    sell_pressure_pct,
+                    config.big_depth_min_pressure_pct,
+                ) {
                     continue;
                 }
 


### PR DESCRIPTION
### Motivation
- Remove the unwanted timestamp from aggregated-trade log lines and simplify the log format to the requested fields.
- Make depth-pressure filtering explicit by computing both bid and sell pressure and applying the threshold against either side.
- Prevent confusing `-0.0%` output by keeping the signed-zero normalization for bid pressure.

### Description
- Removed `ts_str` generation and the `time_helpers` import and changed `log_and_broadcast` in `src/binance.rs` to emit `"[AGG_TRADE] SYMBOL - Price..."` without the timestamp.
- Added explicit sell pressure computation (`sell_pressure_pct = (100.0 - bid_pressure_pct).clamp(0.0, 100.0)`) in `src/main.rs` and passed both `bid_pressure_pct` and `sell_pressure_pct` to the pressure filter.
- Changed `passes_pressure_filter` signature in `src/binance_depth.rs` to `passes_pressure_filter(bid_pressure_pct: f64, sell_pressure_pct: f64, min_pressure_pct: f64)` and updated logic to clamp both sides and apply `bid >= threshold || sell >= threshold`.
- Updated unit tests in `src/binance_depth_tests.rs` to exercise the new two-argument pressure API and clamping behavior.

### Testing
- Attempted to run `cargo fmt && cargo test`, but the run failed because `rustup` could not sync the toolchain due to a network/tunnel error, so automated tests were not executed.
- Verified source edits and local diffs for `src/binance.rs`, `src/main.rs`, `src/binance_depth.rs`, and `src/binance_depth_tests.rs` to ensure consistent API and call-site updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8ed97080832d8c92ebb76657f726)