### PR TITLE
Replace DEPTH cooldown with visual pressure bar and compact notional output

### DIFF
--- a/src/binance_depth.rs
+++ b/src/binance_depth.rs
@@ -105,6 +105,30 @@ pub fn build_diff_depth_streams(symbols: &[String], speed_ms: u16) -> Vec<String
         .collect()
 }
 
+pub fn format_pressure_visual(bid_pressure_pct: f64, width: usize) -> String {
+    let clamped = bid_pressure_pct.clamp(0.0, 100.0);
+    let total_slots = width.max(1);
+    let filled = ((clamped / 100.0) * total_slots as f64).round() as usize;
+    let filled = filled.min(total_slots);
+    let empty = total_slots - filled;
+
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
+}
+
+pub fn format_notional_compact(notional: f64) -> String {
+    let value = notional.abs();
+
+    if value >= 1_000_000_000.0 {
+        format!("{:.2}B", notional / 1_000_000_000.0)
+    } else if value >= 1_000_000.0 {
+        format!("{:.2}M", notional / 1_000_000.0)
+    } else if value >= 1_000.0 {
+        format!("{:.1}K", notional / 1_000.0)
+    } else {
+        format!("{:.0}", notional)
+    }
+}
+
 #[cfg(test)]
 #[path = "binance_depth_tests.rs"]
 mod tests;

--- a/src/binance_depth_tests.rs
+++ b/src/binance_depth_tests.rs
@@ -112,6 +112,20 @@ fn format_depth_levels_uses_compact_representation() {
 }
 
 #[test]
+fn format_pressure_visual_renders_balance_bar() {
+    assert_eq!(format_pressure_visual(0.0, 10), "░░░░░░░░░░");
+    assert_eq!(format_pressure_visual(50.0, 10), "█████░░░░░");
+    assert_eq!(format_pressure_visual(100.0, 10), "██████████");
+}
+
+#[test]
+fn format_notional_compact_uses_suffixes() {
+    assert_eq!(format_notional_compact(980.0), "980");
+    assert_eq!(format_notional_compact(1_540.0), "1.5K");
+    assert_eq!(format_notional_compact(2_750_000.0), "2.75M");
+}
+
+#[test]
 fn build_depth_stream_names() {
     let symbols = vec!["btcusdt".to_string(), "ETHUSDT".to_string()];
     let streams = build_depth_streams(&symbols, 20, 100);


### PR DESCRIPTION
### Motivation
- Feedback asked to replace the time-based cooldown with a visual, string-based representation to make depth signals more insightful at a glance.  
- The cooldown was reducing signal clarity; a compact visual should surface directional pressure and magnitude without suppressing events.  

### Description
- Removed the `big_depth_cooldown_ms` surface and its runtime gating so depth updates are no longer rate-limited (changes in `src/config.rs` and removal of cooldown checks in `src/main.rs`).  
- Added two formatting helpers in `src/binance_depth.rs`: `format_pressure_visual(bid_pressure_pct, width)` to render a `█/░` pressure bar and `format_notional_compact(notional)` to render compact `K/M/B` notional strings.  
- Reworked the `[DEPTH]` output in `src/main.rs` to a concise, interpretable format that includes dominant side, the pressure bar, bid/sell percentages, compact bid/ask notionals and top bid/ask levels.  
- Replaced the previous cooldown-focused unit tests with tests that validate the new format helpers in `src/binance_depth_tests.rs` (and kept existing parsing/stream-name tests).  

### Testing
- Added unit tests for `format_pressure_visual` and `format_notional_compact` in `src/binance_depth_tests.rs`, but test execution failed in this environment.  
- Attempted `cargo test --lib`, but the toolchain bootstrap failed due to a `rustup` network/tunnel error (`unsuccessful tunnel`), so automated tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c24946cd8832da75edcada6f51609)