### PR TITLE
Add websocket keepalive pong timeout handling

### DIFF
--- a/docs/websocket-disconnect-reasons.md
+++ b/docs/websocket-disconnect-reasons.md
@@ -13,6 +13,7 @@ Client disconnected: client sent close frame: browser tab closed
 Possible reason categories include:
 - client sent close frame (with or without reason text)
 - heartbeat ping send failed
+- heartbeat pong timeout
 - broadcast channel closed
 - broadcast forward failed
 - websocket read error
@@ -22,6 +23,8 @@ Possible reason categories include:
 
 This makes operational debugging easier by distinguishing intentional client closes from transport or server-side failures.
 
+The heartbeat flow now also enforces a pong timeout, so stale clients that stop responding are cleaned up instead of being kept alive indefinitely.
+
 ## Validation
 
-See end-to-end coverage in `tests/ws_disconnect_reason_e2e.rs`, which performs a real websocket handshake and close frame exchange without mocks.
+See end-to-end coverage in `tests/ws_disconnect_reason_e2e.rs`, which performs a real websocket handshake and close frame exchange and heartbeat-timeout detection without mocks.

--- a/src/ws_helpers.rs
+++ b/src/ws_helpers.rs
@@ -1,7 +1,7 @@
 // File: src/ws_helpers.rs
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::{broadcast, oneshot};
-use tokio::time::{Duration, interval};
+use tokio::time::{Duration, Instant, interval};
 use warp::ws::{Message, WebSocket};
 
 pub type BroadcastRx = broadcast::Receiver<String>;
@@ -11,6 +11,7 @@ pub type WsTx = futures_util::stream::SplitSink<WebSocket, Message>;
 pub enum DisconnectReason {
     ClientClosed(Option<String>),
     HeartbeatSendFailed,
+    HeartbeatTimeout,
     BroadcastReceiveClosed,
     BroadcastForwardFailed,
     ReceiveError(String),
@@ -25,6 +26,7 @@ impl DisconnectReason {
             }
             Self::ClientClosed(_) => "client sent close frame without reason".to_string(),
             Self::HeartbeatSendFailed => "failed to send heartbeat ping".to_string(),
+            Self::HeartbeatTimeout => "client heartbeat timed out waiting for pong".to_string(),
             Self::BroadcastReceiveClosed => "broadcast channel closed".to_string(),
             Self::BroadcastForwardFailed => {
                 "failed to forward broadcast message to client".to_string()
@@ -62,7 +64,14 @@ pub async fn handle_incoming(ws_tx: &mut WsTx, msg: Message) -> Option<Disconnec
 }
 
 pub async fn handle_client(ws: WebSocket, tx: broadcast::Sender<String>) {
-    handle_client_with_notifier(ws, tx, None).await;
+    handle_client_with_settings(
+        ws,
+        tx,
+        None,
+        Duration::from_secs(15),
+        Duration::from_secs(45),
+    )
+    .await;
 }
 
 pub async fn handle_client_with_notifier(
@@ -70,15 +79,37 @@ pub async fn handle_client_with_notifier(
     tx: broadcast::Sender<String>,
     disconnect_notifier: Option<oneshot::Sender<String>>,
 ) {
+    handle_client_with_settings(
+        ws,
+        tx,
+        disconnect_notifier,
+        Duration::from_secs(15),
+        Duration::from_secs(45),
+    )
+    .await;
+}
+
+pub async fn handle_client_with_settings(
+    ws: WebSocket,
+    tx: broadcast::Sender<String>,
+    disconnect_notifier: Option<oneshot::Sender<String>>,
+    heartbeat_interval: Duration,
+    pong_timeout: Duration,
+) {
     let (mut ws_tx, mut ws_rx) = ws.split();
     let mut rx = tx.subscribe();
-    let mut heartbeat = interval(Duration::from_secs(15));
+    let mut heartbeat = interval(heartbeat_interval);
+    let mut last_pong = Instant::now();
 
     let disconnect_reason = loop {
         tokio::select! {
             _ = heartbeat.tick() => {
                 if send_heartbeat(&mut ws_tx).await.is_err() {
                     break DisconnectReason::HeartbeatSendFailed;
+                }
+
+                if last_pong.elapsed() > pong_timeout {
+                    break DisconnectReason::HeartbeatTimeout;
                 }
             }
             recv_result = rx.recv() => {
@@ -94,6 +125,11 @@ pub async fn handle_client_with_notifier(
             maybe_msg = ws_rx.next() => {
                 match maybe_msg {
                     Some(Ok(msg)) => {
+                        if msg.is_pong() {
+                            last_pong = Instant::now();
+                            continue;
+                        }
+
                         if let Some(reason) = handle_incoming(&mut ws_tx, msg).await {
                             break reason;
                         }

--- a/tests/ws_disconnect_reason_e2e.rs
+++ b/tests/ws_disconnect_reason_e2e.rs
@@ -1,4 +1,4 @@
-use feeder_service::ws_helpers::handle_client_with_notifier;
+use feeder_service::ws_helpers::{handle_client_with_notifier, handle_client_with_settings};
 use futures_util::SinkExt;
 use std::net::TcpListener;
 use std::sync::Arc;
@@ -65,4 +65,60 @@ async fn reports_client_close_reason_on_disconnect() {
 
     assert!(disconnect_reason.contains("client sent close frame"));
     assert!(disconnect_reason.contains("browser tab closed"));
+}
+
+#[tokio::test]
+async fn reports_heartbeat_timeout_when_client_does_not_pong() {
+    let (broadcast_tx, _broadcast_rx) = broadcast::channel::<String>(8);
+    let (disconnect_tx, disconnect_rx) = oneshot::channel::<String>();
+    let disconnect_tx = Arc::new(Mutex::new(Some(disconnect_tx)));
+
+    let ws_route = warp::path("aggTrade").and(warp::ws()).map({
+        let tx = broadcast_tx.clone();
+        let disconnect_tx = Arc::clone(&disconnect_tx);
+        move |ws: warp::ws::Ws| {
+            let tx_inner = tx.clone();
+            let disconnect_tx = Arc::clone(&disconnect_tx);
+            ws.on_upgrade(move |socket| async move {
+                let notifier = disconnect_tx.lock().await.take();
+                handle_client_with_settings(
+                    socket,
+                    tx_inner,
+                    notifier,
+                    std::time::Duration::from_millis(100),
+                    std::time::Duration::from_millis(250),
+                )
+                .await;
+            })
+        }
+    });
+
+    let std_listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = std_listener.local_addr().expect("read local addr");
+    drop(std_listener);
+
+    tokio::task::spawn(warp::serve(ws_route).run(([127, 0, 0, 1], addr.port())));
+
+    let ws_url =
+        Url::parse(&format!("ws://127.0.0.1:{}/aggTrade", addr.port())).expect("build ws url");
+
+    let mut connected = None;
+    for _ in 0..20 {
+        match connect_async(ws_url.clone()).await {
+            Ok(client) => {
+                connected = Some(client);
+                break;
+            }
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+        }
+    }
+
+    let (_client, _) = connected.expect("connect websocket");
+
+    let disconnect_reason = tokio::time::timeout(std::time::Duration::from_secs(3), disconnect_rx)
+        .await
+        .expect("disconnect timeout")
+        .expect("disconnect signal");
+
+    assert!(disconnect_reason.contains("heartbeat timed out"));
 }


### PR DESCRIPTION
### Motivation
- Ensure websocket client connections are cleaned up when clients stop responding to pings instead of being kept alive indefinitely. 
- Provide a configurable keepalive implementation while preserving the existing `handle_client` and `handle_client_with_notifier` APIs. 
- Improve observability by adding a clear disconnect reason for missing pong responses.

### Description
- Add a configurable helper `handle_client_with_settings(ws, tx, notifier, heartbeat_interval, pong_timeout)` that drives ping/pong keepalive and routes existing entrypoints to it. 
- Track the last received pong via `Instant::now()` and disconnect when the elapsed time exceeds the configured `pong_timeout`, emitting a new `DisconnectReason::HeartbeatTimeout`. 
- Update `handle_incoming` to respond to pings and treat incoming pongs as keepalive updates, and route `handle_client`/`handle_client_with_notifier` through the new helper with default intervals (`15s` ping, `45s` timeout). 
- Add an end-to-end test `reports_heartbeat_timeout_when_client_does_not_pong` in `tests/ws_disconnect_reason_e2e.rs` and update `docs/websocket-disconnect-reasons.md` to document the new reason.

### Testing
- Ran `cargo test --test ws_disconnect_reason_e2e` which executed two tests and passed (`reports_client_close_reason_on_disconnect` and `reports_heartbeat_timeout_when_client_does_not_pong`). 
- Ran `cargo fmt --all`, installing `rustfmt` via `rustup component add rustfmt` when required, and formatting completed successfully. 
- All automated checks executed in this change succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4ad8f30483298ee227ea8ba0e155)