### PR TITLE
Add news ingestion pipeline, SQLite store, and scheduled fetch loop

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,17 @@ pub struct Config {
     pub big_depth_min_pressure_pct: f64,
     /// When `true`, depth streams are not subscribed and depth messages are not processed.
     pub disable_depth_stream: bool,
+    pub news: NewsConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewsConfig {
+    pub enabled: bool,
+    pub db_path: String,
+    pub poll_interval_secs: u64,
+    pub retention_hours: i64,
+    pub finnhub_api_key: Option<String>,
+    pub newsapi_api_key: Option<String>,
 }
 
 impl Config {
@@ -86,6 +97,26 @@ impl Config {
             })
             .unwrap_or(false);
 
+        let news = NewsConfig {
+            enabled: env::var("ENABLE_NEWS_INGEST")
+                .map(|v| {
+                    let value = v.trim().trim_matches('"').trim_matches('\'').to_lowercase();
+                    matches!(value.as_str(), "1" | "true" | "yes")
+                })
+                .unwrap_or(false),
+            db_path: env::var("NEWS_DB_PATH").unwrap_or_else(|_| "news.sqlite".to_string()),
+            poll_interval_secs: env::var("NEWS_POLL_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(300),
+            retention_hours: env::var("NEWS_RETENTION_HOURS")
+                .ok()
+                .and_then(|v| v.parse::<i64>().ok())
+                .unwrap_or(24 * 7),
+            finnhub_api_key: env::var("FINNHUB_API_KEY").ok(),
+            newsapi_api_key: env::var("NEWSAPI_API_KEY").ok(),
+        };
+
         Config {
             symbols,
             port,
@@ -94,6 +125,7 @@ impl Config {
             big_depth_min_notional,
             big_depth_min_pressure_pct,
             disable_depth_stream,
+            news,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ pub mod json_helpers;
 pub mod refactor;
 pub mod time_helpers;
 pub mod ws_helpers;
+
+pub mod news;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,16 @@
 use feeder_service::binance::*;
 use feeder_service::binance_depth::*;
 use feeder_service::binance_kline::*;
-use feeder_service::config::Config;
+use feeder_service::config::{Config, NewsConfig};
 use feeder_service::ws_helpers::*;
+use feeder_service::news::providers::fetch_all_news;
+use feeder_service::news::store::NewsStore;
+use feeder_service::news::tagging::tag_symbols;
 use futures_util::StreamExt;
 use local_ip_address::local_ip;
 use std::collections::HashMap;
 use tokio::sync::broadcast;
+use tokio::time::{Duration, interval};
 use tokio_tungstenite::connect_async;
 use warp::Filter;
 
@@ -91,6 +95,17 @@ async fn main() {
     }
 
     tokio::spawn(warp::serve(ws_route).run(([0, 0, 0, 0], config.port)));
+
+    if config.news.enabled {
+        let news_cfg = config.news.clone();
+        tokio::spawn(async move {
+            if let Err(err) = run_news_ingest_loop(news_cfg).await {
+                eprintln!("[news] ingest loop terminated: {err}");
+            }
+        });
+    } else {
+        println!("[news] ingestion is disabled (set ENABLE_NEWS_INGEST=true to enable)");
+    }
 
     // Build Binance streams: aggTrade for each symbol + diff depth streams (unless disabled)
     let mut streams: Vec<String> = symbols.iter().map(|s| format!("{}@aggTrade", s)).collect();
@@ -382,5 +397,42 @@ fn process_kline_event(
 
         println!("{}", msg);
         let _ = tx.send(msg);
+    }
+}
+
+
+async fn run_news_ingest_loop(news_config: NewsConfig) -> anyhow::Result<()> {
+    let store = NewsStore::new(news_config.db_path.clone());
+    store.init()?;
+
+    let http = reqwest::Client::builder()
+        .user_agent("feeder-service-news/0.1")
+        .timeout(Duration::from_secs(20))
+        .build()?;
+
+    let mut ticker = interval(Duration::from_secs(news_config.poll_interval_secs.max(30)));
+
+    loop {
+        ticker.tick().await;
+
+        let mut fetched = fetch_all_news(&http, &news_config).await?;
+        for item in &mut fetched {
+            tag_symbols(item);
+        }
+
+        fetched.sort_by_key(|item| item.published_at);
+
+        let inserted = store.upsert_many(&fetched)?;
+
+        let retention_cutoff = chrono::Utc::now().timestamp() - (news_config.retention_hours * 3600);
+        let pruned = store.prune_older_than(retention_cutoff)?;
+
+        println!(
+            "[news] fetched={} inserted={} pruned={} db={}",
+            fetched.len(),
+            inserted,
+            pruned,
+            news_config.db_path
+        );
     }
 }

--- a/src/news/mod.rs
+++ b/src/news/mod.rs
@@ -1,0 +1,4 @@
+pub mod providers;
+pub mod store;
+pub mod tagging;
+pub mod types;

--- a/src/news/providers/mod.rs
+++ b/src/news/providers/mod.rs
@@ -1,0 +1,135 @@
+use crate::news::types::NewsItem;
+use anyhow::Result;
+use reqwest::Client;
+use serde::Deserialize;
+
+pub async fn fetch_all_news(
+    client: &Client,
+    config: &crate::config::NewsConfig,
+) -> Result<Vec<NewsItem>> {
+    let mut items = Vec::new();
+
+    if let Some(api_key) = config.finnhub_api_key.as_deref() {
+        match fetch_finnhub_news(client, api_key).await {
+            Ok(mut provider_items) => items.append(&mut provider_items),
+            Err(err) => eprintln!("[news] finnhub fetch failed: {err}"),
+        }
+    }
+
+    if let Some(api_key) = config.newsapi_api_key.as_deref() {
+        match fetch_newsapi_news(client, api_key).await {
+            Ok(mut provider_items) => items.append(&mut provider_items),
+            Err(err) => eprintln!("[news] newsapi fetch failed: {err}"),
+        }
+    }
+
+    Ok(items)
+}
+
+#[derive(Debug, Deserialize)]
+struct FinnhubArticle {
+    id: i64,
+    datetime: i64,
+    headline: String,
+    summary: String,
+    url: String,
+    source: String,
+}
+
+async fn fetch_finnhub_news(client: &Client, api_key: &str) -> Result<Vec<NewsItem>> {
+    let url = "https://finnhub.io/api/v1/news?category=crypto";
+    let payload = client
+        .get(url)
+        .query(&[("token", api_key)])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Vec<FinnhubArticle>>()
+        .await?;
+
+    let items = payload
+        .into_iter()
+        .map(|article| NewsItem {
+            id: article.id.to_string(),
+            source: article.source,
+            published_at: article.datetime,
+            title: article.headline,
+            summary: article.summary,
+            url: article.url,
+            symbols: Vec::new(),
+            sentiment_score: None,
+        })
+        .collect();
+
+    Ok(items)
+}
+
+#[derive(Debug, Deserialize)]
+struct NewsApiEnvelope {
+    articles: Vec<NewsApiArticle>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NewsApiArticle {
+    title: Option<String>,
+    description: Option<String>,
+    url: String,
+    #[serde(rename = "publishedAt")]
+    published_at: Option<String>,
+    source: NewsApiSource,
+}
+
+#[derive(Debug, Deserialize)]
+struct NewsApiSource {
+    name: Option<String>,
+}
+
+async fn fetch_newsapi_news(client: &Client, api_key: &str) -> Result<Vec<NewsItem>> {
+    let url = "https://newsapi.org/v2/everything";
+    let payload = client
+        .get(url)
+        .query(&[
+            ("q", "crypto OR bitcoin OR ethereum"),
+            ("language", "en"),
+            ("sortBy", "publishedAt"),
+            ("pageSize", "50"),
+            ("apiKey", api_key),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<NewsApiEnvelope>()
+        .await?;
+
+    let items = payload
+        .articles
+        .into_iter()
+        .enumerate()
+        .map(|(index, article)| {
+            let timestamp = article
+                .published_at
+                .as_deref()
+                .and_then(parse_iso8601_timestamp)
+                .unwrap_or(0);
+
+            NewsItem {
+                id: format!("newsapi-{index}-{}", article.url),
+                source: article.source.name.unwrap_or_else(|| "newsapi".to_string()),
+                published_at: timestamp,
+                title: article.title.unwrap_or_default(),
+                summary: article.description.unwrap_or_default(),
+                url: article.url,
+                symbols: Vec::new(),
+                sentiment_score: None,
+            }
+        })
+        .collect();
+
+    Ok(items)
+}
+
+fn parse_iso8601_timestamp(value: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|ts| ts.timestamp())
+}

--- a/src/news/store.rs
+++ b/src/news/store.rs
@@ -1,0 +1,95 @@
+use crate::news::types::NewsItem;
+use anyhow::Result;
+use rusqlite::{Connection, params};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+#[derive(Debug, Clone)]
+pub struct NewsStore {
+    db_path: String,
+}
+
+impl NewsStore {
+    pub fn new(db_path: impl Into<String>) -> Self {
+        Self {
+            db_path: db_path.into(),
+        }
+    }
+
+    pub fn init(&self) -> Result<()> {
+        let conn = Connection::open(&self.db_path)?;
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS news_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider TEXT NOT NULL,
+                article_id TEXT NOT NULL,
+                published_at INTEGER NOT NULL,
+                title TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                url TEXT NOT NULL,
+                url_hash TEXT NOT NULL,
+                symbols TEXT NOT NULL,
+                sentiment_score REAL,
+                inserted_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+                UNIQUE(provider, article_id),
+                UNIQUE(url_hash)
+            );
+            CREATE INDEX IF NOT EXISTS idx_news_items_published_at
+                ON news_items(published_at DESC);
+            ",
+        )?;
+        Ok(())
+    }
+
+    pub fn upsert_many(&self, items: &[NewsItem]) -> Result<usize> {
+        let mut conn = Connection::open(&self.db_path)?;
+        let tx = conn.transaction()?;
+        let mut inserted = 0usize;
+
+        for item in items {
+            let url_hash = hash_url(&item.url);
+            let symbols_json = serde_json::to_string(&item.symbols)?;
+
+            let changed = tx.execute(
+                "
+                INSERT OR IGNORE INTO news_items
+                    (provider, article_id, published_at, title, summary, url, url_hash, symbols, sentiment_score)
+                VALUES
+                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                ",
+                params![
+                    item.source,
+                    item.id,
+                    item.published_at,
+                    item.title,
+                    item.summary,
+                    item.url,
+                    url_hash,
+                    symbols_json,
+                    item.sentiment_score,
+                ],
+            )?;
+            inserted += changed;
+        }
+
+        tx.commit()?;
+        Ok(inserted)
+    }
+
+    pub fn prune_older_than(&self, min_published_at: i64) -> Result<usize> {
+        let conn = Connection::open(&self.db_path)?;
+        let deleted = conn.execute(
+            "DELETE FROM news_items WHERE published_at > 0 AND published_at < ?1",
+            params![min_published_at],
+        )?;
+        Ok(deleted)
+    }
+}
+
+fn hash_url(url: &str) -> String {
+    let canonical = url.trim().to_lowercase();
+    let mut hasher = DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}

--- a/src/news/tagging.rs
+++ b/src/news/tagging.rs
@@ -1,0 +1,29 @@
+use crate::news::types::NewsItem;
+
+const SYMBOL_ALIASES: [(&str, &str); 12] = [
+    ("btc", "btcusdt"),
+    ("bitcoin", "btcusdt"),
+    ("eth", "ethusdt"),
+    ("ethereum", "ethusdt"),
+    ("sol", "solusdt"),
+    ("solana", "solusdt"),
+    ("bnb", "bnbusdt"),
+    ("binance coin", "bnbusdt"),
+    ("xrp", "xrpusdt"),
+    ("ripple", "xrpusdt"),
+    ("doge", "dogeusdt"),
+    ("dogecoin", "dogeusdt"),
+];
+
+pub fn tag_symbols(item: &mut NewsItem) {
+    let haystack = format!("{} {}", item.title, item.summary).to_lowercase();
+    let mut symbols: Vec<String> = SYMBOL_ALIASES
+        .iter()
+        .filter_map(|(alias, canonical)| haystack.contains(alias).then_some(*canonical))
+        .map(str::to_string)
+        .collect();
+
+    symbols.sort();
+    symbols.dedup();
+    item.symbols = symbols;
+}

--- a/src/news/types.rs
+++ b/src/news/types.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NewsItem {
+    pub id: String,
+    pub source: String,
+    pub published_at: i64,
+    pub title: String,
+    pub summary: String,
+    pub url: String,
+    pub symbols: Vec<String>,
+    pub sentiment_score: Option<f64>,
+}

--- a/tests/quant_vector_4h_e2e.rs
+++ b/tests/quant_vector_4h_e2e.rs
@@ -1,7 +1,7 @@
 use feeder_service::{
     binance_depth::DepthUpdate,
     binance_kline::parse_kline_event,
-    config::{Config, SymbolConfig},
+    config::{Config, NewsConfig, SymbolConfig},
     refactor::AppState,
 };
 use tokio::sync::broadcast;
@@ -31,6 +31,14 @@ async fn quant_vector_uses_closed_4h_kline_and_stays_separate_from_depth() {
         big_depth_min_notional: 0.0,
         big_depth_min_pressure_pct: 0.0,
         disable_depth_stream: false,
+        news: NewsConfig {
+            enabled: false,
+            db_path: "news.sqlite".to_string(),
+            poll_interval_secs: 300,
+            retention_hours: 168,
+            finnhub_api_key: None,
+            newsapi_api_key: None,
+        },
     };
 
     let mut app = AppState::new(config);

--- a/tests/quant_vector_4h_open_kline_no_signal_e2e.rs
+++ b/tests/quant_vector_4h_open_kline_no_signal_e2e.rs
@@ -1,6 +1,6 @@
 use feeder_service::{
     binance_kline::parse_kline_event,
-    config::{Config, SymbolConfig},
+    config::{Config, NewsConfig, SymbolConfig},
     refactor::AppState,
 };
 use tokio::sync::broadcast;
@@ -19,6 +19,14 @@ async fn quant_vector_ignores_open_4h_kline_events() {
         big_depth_min_notional: 0.0,
         big_depth_min_pressure_pct: 0.0,
         disable_depth_stream: false,
+        news: NewsConfig {
+            enabled: false,
+            db_path: "news.sqlite".to_string(),
+            poll_interval_secs: 300,
+            retention_hours: 168,
+            finnhub_api_key: None,
+            newsapi_api_key: None,
+        },
     };
 
     let app = AppState::new(config);


### PR DESCRIPTION
### Motivation
- Introduce a news ingestion pipeline to fetch crypto-related articles from external providers, normalize them, tag symbols, and persist recent items for downstream use.
- Provide a configurable, environment-driven ingest that can be enabled/disabled, with retention and polling controls to limit storage and network usage.

### Description
- Added a new `news` module (`src/news/`) with `types.rs` (`NewsItem`), `providers/mod.rs` (Finnhub + NewsAPI adapters using `reqwest`), `tagging.rs` (symbol alias -> canonical mapping), and `store.rs` (SQLite persistence with uniqueness on `(provider, article_id)` and `url_hash`).
- Extended `Config` in `src/config.rs` with a `NewsConfig` struct and environment variables `ENABLE_NEWS_INGEST`, `NEWS_DB_PATH`, `NEWS_POLL_INTERVAL_SECS`, `NEWS_RETENTION_HOURS`, `FINNHUB_API_KEY`, and `NEWSAPI_API_KEY`.
- Wired a periodic Tokio task in `src/main.rs` (`run_news_ingest_loop`) that initializes `NewsStore`, fetches provider articles, applies `tag_symbols`, sorts/deduplicates via `upsert_many`, and prunes old records according to retention.
- Exported the `news` module from `src/lib.rs` and updated tests that construct `Config` to include the new `news` field.

### Testing
- Ran `cargo test` and all unit and integration tests completed successfully (`cargo test` finished with tests passing). 
- Attempted `cargo fmt` but it could not be executed in this environment because `rustfmt` is not installed. 
- Verified the new modules compile as part of the test run and the modified tests were updated to include `NewsConfig` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aea18833b48329a84ffa5549baa411)