### PR TITLE
Add news correlation enrichment to websocket signal pipeline

### DIFF
--- a/docs/news-correlation.md
+++ b/docs/news-correlation.md
@@ -1,0 +1,40 @@
+# News Correlation Enrichment
+
+The websocket stream now emits **two messages** for qualifying signals:
+
+1. Existing plain-text signal log line (backward compatible).
+2. Enriched JSON payload for downstream consumers.
+
+## Enriched payload shape
+
+```json
+{
+  "signal_type": "agg_trade|depth_update|kline_quant",
+  "symbol": "BTCUSDT",
+  "event_timestamp": 1710000001000,
+  "move_metrics": {
+    "...": "signal-specific metrics"
+  },
+  "matched_news": [
+    {
+      "headline": "Bitcoin ETF inflow surges",
+      "url": "https://example.com/article",
+      "published_at": 1710000000500
+    }
+  ],
+  "correlation_score": 0.2
+}
+```
+
+## Correlation window
+
+The service queries `news_items` by `published_at` and symbol tag match in a configurable
+window around the signal event timestamp.
+
+Environment variables:
+
+- `NEWS_CORRELATION_LOOKBACK_SECS` (default: `900`, i.e. 15m)
+- `NEWS_CORRELATION_LOOKAHEAD_SECS` (default: `1800`, i.e. 30m)
+- `NEWS_CORRELATION_MAX_MATCHES` (default: `5`)
+
+The score is currently a simple normalized match count (`matches / 5`, clamped to 1.0).

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,14 @@ use feeder_service::binance::*;
 use feeder_service::binance_depth::*;
 use feeder_service::binance_kline::*;
 use feeder_service::config::{Config, NewsConfig};
+use feeder_service::news::correlation::CorrelationService;
 use feeder_service::news::providers::fetch_all_news;
 use feeder_service::news::store::NewsStore;
 use feeder_service::news::tagging::tag_symbols;
 use feeder_service::ws_helpers::*;
 use futures_util::StreamExt;
 use local_ip_address::local_ip;
+use serde_json::json;
 use std::collections::HashMap;
 use tokio::sync::broadcast;
 use tokio::time::{Duration, interval};
@@ -61,6 +63,15 @@ async fn main() {
     }
 
     let (tx, _rx) = broadcast::channel(config.broadcast_capacity);
+    let correlation_service = NewsStore::new(config.news.db_path.clone());
+    let correlation_service = match correlation_service.init() {
+        Ok(()) => Some(CorrelationService::from_env(correlation_service)),
+        Err(err) => {
+            eprintln!("[news] correlation disabled, failed to init db: {err}");
+            None
+        }
+    };
+
 
     // Spawn Warp server for websocket clients
     let ws_route = warp::path("aggTrade").and(warp::ws()).map({
@@ -148,7 +159,7 @@ async fn main() {
 
             // 1) aggTrade messages
             if let Some(agg) = parse_agg_trade(payload) {
-                process_agg_trade(&agg, &config_map, &mut last_prices, &tx).await;
+                process_agg_trade(&agg, &config_map, &mut last_prices, &tx, correlation_service.as_ref()).await;
                 continue;
             }
 
@@ -161,6 +172,7 @@ async fn main() {
                         &config,
                         &mut big_move_detectors,
                         &tx,
+                        correlation_service.as_ref(),
                     );
                     continue;
                 }
@@ -169,7 +181,7 @@ async fn main() {
             // 3) kline updates (4h quant vector signal on closed candles)
             if enable_kline_quant {
                 if let Some(kline_event) = parse_kline_event(payload) {
-                    process_kline_event(&kline_event, &config_map, &tx);
+                    process_kline_event(&kline_event, &config_map, &tx, correlation_service.as_ref());
                     continue;
                 }
             }
@@ -193,6 +205,7 @@ async fn process_agg_trade(
     config_map: &HashMap<String, feeder_service::config::SymbolConfig>,
     last_prices: &mut HashMap<String, f64>,
     tx: &broadcast::Sender<String>,
+    correlation_service: Option<&CorrelationService>,
 ) {
     let symbol = agg.s.to_lowercase();
     let cfg = match config_map.get(&symbol) {
@@ -208,6 +221,20 @@ async fn process_agg_trade(
 
     // Preserve asynchronous logging & broadcasting behaviour
     log_and_broadcast(tx, agg, spike, cfg).await;
+
+    build_and_send_enriched_payload(
+        tx,
+        correlation_service,
+        "agg_trade",
+        &symbol,
+        agg.t as i64,
+        json!({
+            "price": current_price,
+            "quantity": agg.q.parse::<f64>().unwrap_or(0.0),
+            "spike_pct": spike,
+            "buyer_maker": agg.m,
+        }),
+    );
 }
 
 fn process_depth_update(
@@ -216,6 +243,7 @@ fn process_depth_update(
     config: &Config,
     big_move_detectors: &mut HashMap<String, BigMoveDetector>,
     tx: &broadcast::Sender<String>,
+    correlation_service: Option<&CorrelationService>,
 ) {
     let symbol = depth.symbol.to_lowercase();
     let cfg = match config_map.get(&symbol) {
@@ -321,6 +349,21 @@ fn process_depth_update(
     println!("{}", depth_msg);
     let _ = tx.send(depth_msg.clone());
 
+    build_and_send_enriched_payload(
+        tx,
+        correlation_service,
+        "depth_update",
+        &symbol,
+        depth.event_time as i64,
+        json!({
+            "bid_pressure_pct": bid_pressure_pct,
+            "sell_pressure_pct": sell_pressure_pct,
+            "total_notional": total_notional,
+            "top_bid_count": big_bids.len(),
+            "top_ask_count": big_asks.len(),
+        }),
+    );
+
     if let Some(detector) = big_move_detectors.get_mut(&symbol) {
         let snap = DepthSnapshot {
             bid_pressure_pct,
@@ -363,6 +406,7 @@ fn process_kline_event(
     event: &feeder_service::binance_kline::KlineEvent,
     config_map: &HashMap<String, feeder_service::config::SymbolConfig>,
     tx: &broadcast::Sender<String>,
+    correlation_service: Option<&CorrelationService>,
 ) {
     let symbol = event.symbol.to_lowercase();
     if !config_map.contains_key(&symbol) {
@@ -397,6 +441,49 @@ fn process_kline_event(
 
         println!("{}", msg);
         let _ = tx.send(msg);
+
+        build_and_send_enriched_payload(
+            tx,
+            correlation_service,
+            "kline_quant",
+            &symbol,
+            event.event_time as i64,
+            json!({
+                "return_pct": signal.return_pct,
+                "range_pct": signal.range_pct,
+                "taker_buy_ratio_pct": signal.taker_buy_ratio_pct,
+                "quote_volume": signal.quote_volume,
+                "trade_count": signal.trade_count,
+            }),
+        );
+    }
+}
+
+
+fn build_and_send_enriched_payload(
+    tx: &broadcast::Sender<String>,
+    correlation_service: Option<&CorrelationService>,
+    signal_type: &str,
+    symbol: &str,
+    event_timestamp: i64,
+    move_metrics: serde_json::Value,
+) {
+    let Some(service) = correlation_service else {
+        return;
+    };
+
+    if let Ok(correlation) = service.correlate(symbol, event_timestamp) {
+        let payload = json!({
+            "signal_type": signal_type,
+            "symbol": symbol.to_uppercase(),
+            "event_timestamp": event_timestamp,
+            "move_metrics": move_metrics,
+            "matched_news": correlation.matches,
+            "correlation_score": correlation.score,
+        })
+        .to_string();
+
+        let _ = tx.send(payload);
     }
 }
 

--- a/src/news/correlation.rs
+++ b/src/news/correlation.rs
@@ -1,0 +1,90 @@
+use crate::news::store::{NewsRecord, NewsStore};
+use anyhow::Result;
+use serde::Serialize;
+
+#[derive(Debug, Clone)]
+pub struct CorrelationService {
+    store: NewsStore,
+    default_lookback_ms: i64,
+    default_lookahead_ms: i64,
+    max_matches: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MatchedNews {
+    pub headline: String,
+    pub url: String,
+    pub published_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CorrelationResult {
+    pub lookback_ms: i64,
+    pub lookahead_ms: i64,
+    pub matches: Vec<MatchedNews>,
+    pub score: f64,
+}
+
+impl CorrelationService {
+    pub fn new(
+        store: NewsStore,
+        default_lookback_ms: i64,
+        default_lookahead_ms: i64,
+        max_matches: usize,
+    ) -> Self {
+        Self {
+            store,
+            default_lookback_ms,
+            default_lookahead_ms,
+            max_matches,
+        }
+    }
+
+    pub fn from_env(store: NewsStore) -> Self {
+        let lookback_secs = std::env::var("NEWS_CORRELATION_LOOKBACK_SECS")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(15 * 60);
+        let lookahead_secs = std::env::var("NEWS_CORRELATION_LOOKAHEAD_SECS")
+            .ok()
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(30 * 60);
+        let max_matches = std::env::var("NEWS_CORRELATION_MAX_MATCHES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(5);
+
+        Self::new(
+            store,
+            lookback_secs * 1000,
+            lookahead_secs * 1000,
+            max_matches,
+        )
+    }
+
+    pub fn correlate(&self, symbol: &str, event_ts_ms: i64) -> Result<CorrelationResult> {
+        let from_ts = event_ts_ms - self.default_lookback_ms;
+        let to_ts = event_ts_ms + self.default_lookahead_ms;
+        let records = self
+            .store
+            .get_recent_by_symbol(symbol, from_ts, to_ts, self.max_matches)?;
+
+        Ok(CorrelationResult {
+            lookback_ms: self.default_lookback_ms,
+            lookahead_ms: self.default_lookahead_ms,
+            score: correlation_score(&records),
+            matches: records
+                .into_iter()
+                .map(|record| MatchedNews {
+                    headline: record.title,
+                    url: record.url,
+                    published_at: record.published_at,
+                })
+                .collect(),
+        })
+    }
+}
+
+fn correlation_score(records: &[NewsRecord]) -> f64 {
+    (records.len() as f64).min(5.0) / 5.0
+}

--- a/src/news/mod.rs
+++ b/src/news/mod.rs
@@ -1,3 +1,4 @@
+pub mod correlation;
 pub mod providers;
 pub mod store;
 pub mod tagging;

--- a/src/news/store.rs
+++ b/src/news/store.rs
@@ -5,6 +5,18 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone)]
+pub struct NewsRecord {
+    pub provider: String,
+    pub article_id: String,
+    pub published_at: i64,
+    pub title: String,
+    pub summary: String,
+    pub url: String,
+    pub symbols: Vec<String>,
+    pub sentiment_score: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
 pub struct NewsStore {
     db_path: String,
 }
@@ -85,6 +97,66 @@ impl NewsStore {
         )?;
         Ok(deleted)
     }
+
+    pub fn get_recent_by_symbol(
+        &self,
+        symbol: &str,
+        from_ts: i64,
+        to_ts: i64,
+        limit: usize,
+    ) -> Result<Vec<NewsRecord>> {
+        let conn = Connection::open(&self.db_path)?;
+        let query_limit = (limit.max(1) * 4) as i64;
+        let mut stmt = conn.prepare(
+            "
+            SELECT provider, article_id, published_at, title, summary, url, symbols, sentiment_score
+            FROM news_items
+            WHERE published_at >= ?1 AND published_at <= ?2
+            ORDER BY published_at DESC
+            LIMIT ?3
+            ",
+        )?;
+
+        let rows = stmt.query_map(params![from_ts, to_ts, query_limit], |row| {
+            let raw_symbols: String = row.get(6)?;
+            let symbols = parse_symbols(&raw_symbols);
+            Ok(NewsRecord {
+                provider: row.get(0)?,
+                article_id: row.get(1)?,
+                published_at: row.get(2)?,
+                title: row.get(3)?,
+                summary: row.get(4)?,
+                url: row.get(5)?,
+                symbols,
+                sentiment_score: row.get(7)?,
+            })
+        })?;
+
+        let symbol_upper = symbol.to_ascii_uppercase();
+        let mut filtered = Vec::new();
+        for row in rows {
+            let news = row?;
+            if news
+                .symbols
+                .iter()
+                .any(|item| item.eq_ignore_ascii_case(&symbol_upper))
+            {
+                filtered.push(news);
+            }
+
+            if filtered.len() >= limit {
+                break;
+            }
+        }
+
+        Ok(filtered)
+    }
+}
+
+fn parse_symbols(raw: &str) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(raw)
+        .map(|items| items.into_iter().filter(|item| !item.trim().is_empty()).collect())
+        .unwrap_or_default()
 }
 
 fn hash_url(url: &str) -> String {

--- a/src/refactor/mod.rs
+++ b/src/refactor/mod.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+
+use anyhow::Result;
+use serde_json::json;
 use tokio::sync::broadcast;
 
 use crate::{
@@ -9,6 +12,7 @@ use crate::{
     },
     binance_kline::{KlineEvent, build_quant_signal_from_kline},
     config::{Config, SymbolConfig},
+    news::{correlation::CorrelationService, store::NewsStore},
 };
 
 use self::big_move_detector::{BigMoveDetector, BigMoveSignal, DepthSnapshot};
@@ -24,6 +28,7 @@ pub struct AppState {
     last_prices: HashMap<String, f64>,
     /// Map of symbol to big move detector
     big_move_detectors: HashMap<String, BigMoveDetector>,
+    correlation_service: Option<CorrelationService>,
 }
 
 impl AppState {
@@ -46,14 +51,59 @@ impl AppState {
             );
         }
 
+        let correlation_service = Self::build_correlation_service(&config).ok();
+
         Self {
             config,
             config_map,
             last_prices: HashMap::new(),
             big_move_detectors,
+            correlation_service,
         }
     }
 
+
+    fn build_correlation_service(config: &Config) -> Result<CorrelationService> {
+        let store = NewsStore::new(config.news.db_path.clone());
+        store.init()?;
+        Ok(CorrelationService::from_env(store))
+    }
+
+    fn build_enriched_payload(
+        &self,
+        signal_type: &str,
+        symbol: &str,
+        event_ts_ms: i64,
+        move_metrics: serde_json::Value,
+    ) -> Option<String> {
+        let service = self.correlation_service.as_ref()?;
+        let correlation = service.correlate(symbol, event_ts_ms).ok()?;
+
+        Some(
+            json!({
+                "signal_type": signal_type,
+                "symbol": symbol.to_uppercase(),
+                "event_timestamp": event_ts_ms,
+                "move_metrics": move_metrics,
+                "matched_news": correlation.matches,
+                "correlation_score": correlation.score,
+            })
+            .to_string(),
+        )
+    }
+
+    fn send_enriched_payload(
+        &self,
+        tx: &broadcast::Sender<String>,
+        signal_type: &str,
+        symbol: &str,
+        event_ts_ms: i64,
+        move_metrics: serde_json::Value,
+    ) {
+        if let Some(payload) = self.build_enriched_payload(signal_type, symbol, event_ts_ms, move_metrics) {
+            let _ = tx.send(payload);
+        }
+    }
     pub async fn process_agg_trade(&mut self, agg: &AggTrade, tx: &broadcast::Sender<String>) {
         let symbol = agg.s.to_lowercase();
         let cfg = match self.config_map.get(&symbol) {
@@ -68,6 +118,19 @@ impl AppState {
         self.last_prices.insert(symbol.clone(), current_price);
 
         log_and_broadcast(tx, agg, spike, cfg).await;
+
+        self.send_enriched_payload(
+            tx,
+            "agg_trade",
+            &symbol,
+            agg.t as i64,
+            json!({
+                "price": current_price,
+                "quantity": agg.q.parse::<f64>().unwrap_or(0.0),
+                "spike_pct": spike,
+                "buyer_maker": agg.m,
+            }),
+        );
     }
 
     pub fn process_depth_update(&mut self, depth: &DepthUpdate, tx: &broadcast::Sender<String>) {
@@ -105,6 +168,20 @@ impl AppState {
 
         println!("{}", depth_msg);
         let _ = tx.send(depth_msg.clone());
+
+        self.send_enriched_payload(
+            tx,
+            "depth_update",
+            &symbol,
+            depth.event_time as i64,
+            json!({
+                "bid_pressure_pct": bid_pressure_pct,
+                "sell_pressure_pct": sell_pressure_pct,
+                "total_notional": total_notional,
+                "top_bid_count": big_bids.len(),
+                "top_ask_count": big_asks.len(),
+            }),
+        );
 
         self.detect_big_move(&symbol, bid_pressure_pct, total_notional, depth, tx);
     }
@@ -233,6 +310,20 @@ impl AppState {
             );
             println!("{}", msg);
             let _ = tx.send(msg);
+
+            self.send_enriched_payload(
+                tx,
+                "kline_quant",
+                &symbol,
+                event.event_time as i64,
+                json!({
+                    "return_pct": signal.return_pct,
+                    "range_pct": signal.range_pct,
+                    "taker_buy_ratio_pct": signal.taker_buy_ratio_pct,
+                    "quote_volume": signal.quote_volume,
+                    "trade_count": signal.trade_count,
+                }),
+            );
         }
     }
 

--- a/tests/news_correlation_e2e.rs
+++ b/tests/news_correlation_e2e.rs
@@ -1,0 +1,85 @@
+use feeder_service::binance::AggTrade;
+use feeder_service::config::{Config, NewsConfig, SymbolConfig};
+use feeder_service::news::store::NewsStore;
+use feeder_service::news::types::NewsItem;
+use feeder_service::refactor::AppState;
+use tokio::sync::broadcast;
+
+fn test_db_path(name: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("valid time")
+        .as_nanos();
+    std::env::temp_dir()
+        .join(format!("feeder-service-{name}-{nanos}.sqlite"))
+        .to_string_lossy()
+        .to_string()
+}
+
+#[tokio::test]
+async fn emits_enriched_json_with_news_matches_for_agg_trade() {
+    let db_path = test_db_path("e2e-correlation");
+    let store = NewsStore::new(db_path.clone());
+    store.init().expect("db initialized");
+
+    store
+        .upsert_many(&[NewsItem {
+            id: "article-1".to_string(),
+            source: "test".to_string(),
+            published_at: 1_710_000_000_500,
+            title: "Bitcoin ETF inflow surges".to_string(),
+            summary: "Demand rises".to_string(),
+            url: "https://example.com/bitcoin-etf".to_string(),
+            symbols: vec!["BTCUSDT".to_string()],
+            sentiment_score: Some(0.7),
+        }])
+        .expect("seed news");
+
+    let config = Config {
+        symbols: vec![SymbolConfig {
+            symbol: "btcusdt".to_string(),
+            big_trade_qty: 0.1,
+            spike_pct: 0.2,
+        }],
+        port: 9001,
+        broadcast_capacity: 32,
+        big_depth_min_qty: 0.0,
+        big_depth_min_notional: 0.0,
+        big_depth_min_pressure_pct: 0.0,
+        disable_depth_stream: false,
+        news: NewsConfig {
+            enabled: true,
+            db_path: db_path.clone(),
+            poll_interval_secs: 60,
+            retention_hours: 24,
+            finnhub_api_key: None,
+            newsapi_api_key: None,
+        },
+    };
+
+    let mut app_state = AppState::new(config);
+    let (tx, mut rx) = broadcast::channel(32);
+
+    let agg = AggTrade {
+        s: "BTCUSDT".to_string(),
+        p: "43000.0".to_string(),
+        q: "0.2".to_string(),
+        t: 1_710_000_001_000,
+        m: false,
+    };
+
+    app_state.process_agg_trade(&agg, &tx).await;
+
+    let first = rx.recv().await.expect("plain-text signal");
+    assert!(first.contains("[AGG_TRADE]"));
+
+    let second = rx.recv().await.expect("enriched signal");
+    let payload: serde_json::Value = serde_json::from_str(&second).expect("json payload");
+    assert_eq!(payload["signal_type"], "agg_trade");
+    assert_eq!(payload["symbol"], "BTCUSDT");
+    assert_eq!(payload["matched_news"][0]["headline"], "Bitcoin ETF inflow surges");
+    assert_eq!(payload["matched_news"][0]["url"], "https://example.com/bitcoin-etf");
+    assert!(payload["correlation_score"].as_f64().unwrap_or_default() > 0.0);
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
### Motivation
- Provide downstream consumers with structured context by correlating recent news to market signals and emitting enriched JSON payloads alongside existing plain-text logs.
- Allow configurable time windows and match limits for correlation so operators can tune sensitivity via environment variables.

### Description
- Added a new correlation module `src/news/correlation.rs` that implements `CorrelationService` with configurable lookback/lookahead and `NEWS_CORRELATION_MAX_MATCHES`, and a simple normalized correlation score and payload shaping.
- Extended `NewsStore` in `src/news/store.rs` with a read API `get_recent_by_symbol(symbol, from_ts, to_ts, limit)` that parses the JSON `symbols` column and filters matches case-insensitively, returning `NewsRecord` structs.
- Wired correlation lookups into signal paths by invoking correlation before broadcasting in both the refactor-based `AppState` (`src/refactor/mod.rs`) and the main runtime (`src/main.rs`) for `agg_trade`, `depth_update`, and `kline_quant` flows, while preserving existing plain-text log messages for backward compatibility.
- Emit enriched JSON payloads on the websocket broadcast that include `signal_type`, `symbol`, `event_timestamp`, `move_metrics`, `matched_news` (headline/url/published_at), and `correlation_score`, and added documentation `docs/news-correlation.md` describing the payload and env configuration.
- Added an end-to-end test `tests/news_correlation_e2e.rs` that seeds a real SQLite `news_items` DB (no mocks) and asserts both the plain-text message and the enriched JSON with matched headline/url and non-zero score.

### Testing
- Ran the full test suite with `cargo test` and `cargo test -q`, and all tests passed including the new end-to-end correlation test (`tests/news_correlation_e2e.rs`).
- The e2e test exercises a real SQLite DB (created in a temp path) and verifies the broadcasted enriched JSON without mocking the store.
- Attempted `cargo fmt --all` but it failed in this environment because `rustfmt` is not installed; code compiles and tests succeed without formatting step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeca65af2c832d9b930e5d874244a0)