### PR TITLE
Add symbol-indexed news storage with safe migration and pruning

### DIFF
--- a/docs/news-correlation.md
+++ b/docs/news-correlation.md
@@ -28,8 +28,19 @@ The websocket stream now emits **two messages** for qualifying signals:
 
 ## Correlation window
 
-The service queries `news_items` by `published_at` and symbol tag match in a configurable
-window around the signal event timestamp.
+The service queries a normalized symbol table (`news_item_symbols`) joined to `news_items`
+with indexed predicates on symbol and publish timestamp. This avoids scanning and JSON symbol
+parsing for every candidate row in the correlation window.
+
+The schema includes:
+
+- `news_item_symbols(news_item_id, symbol, published_at)`
+- `idx_news_item_symbols_symbol_news_item (symbol, news_item_id)`
+- `idx_news_item_symbols_symbol_published_at (symbol, published_at DESC, news_item_id)`
+
+`NewsStore::init` uses idempotent migration statements (`CREATE TABLE IF NOT EXISTS` and
+`CREATE INDEX IF NOT EXISTS`) and backfills symbol rows from existing `news_items` records,
+so older databases are upgraded safely.
 
 Environment variables:
 

--- a/src/news/store.rs
+++ b/src/news/store.rs
@@ -1,7 +1,7 @@
 use crate::news::types::NewsItem;
 use anyhow::Result;
 use rusqlite::{Connection, params};
-use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone)]
@@ -29,8 +29,10 @@ impl NewsStore {
     }
 
     pub fn init(&self) -> Result<()> {
-        let conn = Connection::open(&self.db_path)?;
-        conn.execute_batch(
+        let mut conn = Connection::open(&self.db_path)?;
+        let tx = conn.transaction()?;
+
+        tx.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS news_items (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -49,8 +51,45 @@ impl NewsStore {
             );
             CREATE INDEX IF NOT EXISTS idx_news_items_published_at
                 ON news_items(published_at DESC);
+
+            CREATE TABLE IF NOT EXISTS news_item_symbols (
+                news_item_id INTEGER NOT NULL,
+                symbol TEXT NOT NULL,
+                published_at INTEGER NOT NULL,
+                PRIMARY KEY(news_item_id, symbol),
+                FOREIGN KEY(news_item_id) REFERENCES news_items(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_news_item_symbols_symbol_news_item
+                ON news_item_symbols(symbol, news_item_id);
+            CREATE INDEX IF NOT EXISTS idx_news_item_symbols_symbol_published_at
+                ON news_item_symbols(symbol, published_at DESC, news_item_id);
             ",
         )?;
+
+        let mut backfill_stmt = tx.prepare("SELECT id, published_at, symbols FROM news_items")?;
+        let rows = backfill_stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?;
+
+        for row in rows {
+            let (news_item_id, published_at, raw_symbols) = row?;
+            for symbol in parse_symbols(&raw_symbols) {
+                tx.execute(
+                    "
+                    INSERT OR IGNORE INTO news_item_symbols (news_item_id, symbol, published_at)
+                    VALUES (?1, ?2, ?3)
+                    ",
+                    params![news_item_id, symbol, published_at],
+                )?;
+            }
+        }
+
+        drop(backfill_stmt);
+        tx.commit()?;
         Ok(())
     }
 
@@ -61,7 +100,8 @@ impl NewsStore {
 
         for item in items {
             let url_hash = hash_url(&item.url);
-            let symbols_json = serde_json::to_string(&item.symbols)?;
+            let symbols = normalize_symbols(&item.symbols);
+            let symbols_json = serde_json::to_string(&symbols)?;
 
             let changed = tx.execute(
                 "
@@ -83,6 +123,24 @@ impl NewsStore {
                 ],
             )?;
             inserted += changed;
+
+            let news_item_id: i64 = tx.query_row(
+                "SELECT id FROM news_items WHERE provider = ?1 AND article_id = ?2",
+                params![item.source, item.id],
+                |row| row.get(0),
+            )?;
+
+            for symbol in symbols {
+                tx.execute(
+                    "
+                    INSERT INTO news_item_symbols (news_item_id, symbol, published_at)
+                    VALUES (?1, ?2, ?3)
+                    ON CONFLICT(news_item_id, symbol)
+                    DO UPDATE SET published_at = excluded.published_at
+                    ",
+                    params![news_item_id, symbol, item.published_at],
+                )?;
+            }
         }
 
         tx.commit()?;
@@ -90,11 +148,25 @@ impl NewsStore {
     }
 
     pub fn prune_older_than(&self, min_published_at: i64) -> Result<usize> {
-        let conn = Connection::open(&self.db_path)?;
-        let deleted = conn.execute(
+        let mut conn = Connection::open(&self.db_path)?;
+        let tx = conn.transaction()?;
+
+        tx.execute(
+            "
+            DELETE FROM news_item_symbols
+            WHERE news_item_id IN (
+                SELECT id FROM news_items WHERE published_at > 0 AND published_at < ?1
+            )
+            ",
+            params![min_published_at],
+        )?;
+
+        let deleted = tx.execute(
             "DELETE FROM news_items WHERE published_at > 0 AND published_at < ?1",
             params![min_published_at],
         )?;
+
+        tx.commit()?;
         Ok(deleted)
     }
 
@@ -106,20 +178,23 @@ impl NewsStore {
         limit: usize,
     ) -> Result<Vec<NewsRecord>> {
         let conn = Connection::open(&self.db_path)?;
-        let query_limit = (limit.max(1) * 4) as i64;
+        let query_limit = limit.max(1) as i64;
         let mut stmt = conn.prepare(
             "
-            SELECT provider, article_id, published_at, title, summary, url, symbols, sentiment_score
-            FROM news_items
-            WHERE published_at >= ?1 AND published_at <= ?2
-            ORDER BY published_at DESC
-            LIMIT ?3
+            SELECT ni.provider, ni.article_id, ni.published_at, ni.title, ni.summary, ni.url, ni.symbols, ni.sentiment_score
+            FROM news_item_symbols nis
+            INNER JOIN news_items ni ON ni.id = nis.news_item_id
+            WHERE nis.symbol = ?1
+              AND nis.published_at >= ?2
+              AND nis.published_at <= ?3
+            ORDER BY nis.published_at DESC, nis.news_item_id DESC
+            LIMIT ?4
             ",
         )?;
 
-        let rows = stmt.query_map(params![from_ts, to_ts, query_limit], |row| {
+        let symbol_upper = symbol.to_ascii_uppercase();
+        let rows = stmt.query_map(params![symbol_upper, from_ts, to_ts, query_limit], |row| {
             let raw_symbols: String = row.get(6)?;
-            let symbols = parse_symbols(&raw_symbols);
             Ok(NewsRecord {
                 provider: row.get(0)?,
                 article_id: row.get(1)?,
@@ -127,35 +202,42 @@ impl NewsStore {
                 title: row.get(3)?,
                 summary: row.get(4)?,
                 url: row.get(5)?,
-                symbols,
+                symbols: parse_symbols(&raw_symbols),
                 sentiment_score: row.get(7)?,
             })
         })?;
 
-        let symbol_upper = symbol.to_ascii_uppercase();
-        let mut filtered = Vec::new();
+        let mut records = Vec::new();
         for row in rows {
-            let news = row?;
-            if news
-                .symbols
-                .iter()
-                .any(|item| item.eq_ignore_ascii_case(&symbol_upper))
-            {
-                filtered.push(news);
-            }
-
-            if filtered.len() >= limit {
-                break;
-            }
+            records.push(row?);
         }
 
-        Ok(filtered)
+        Ok(records)
     }
+}
+
+fn normalize_symbols(symbols: &[String]) -> Vec<String> {
+    let mut deduped = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for symbol in symbols {
+        let trimmed = symbol.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let upper = trimmed.to_ascii_uppercase();
+        if deduped.insert(upper.clone()) {
+            normalized.push(upper);
+        }
+    }
+
+    normalized
 }
 
 fn parse_symbols(raw: &str) -> Vec<String> {
     serde_json::from_str::<Vec<String>>(raw)
-        .map(|items| items.into_iter().filter(|item| !item.trim().is_empty()).collect())
+        .map(|items| normalize_symbols(&items))
         .unwrap_or_default()
 }
 

--- a/tests/news_store_symbol_index_e2e.rs
+++ b/tests/news_store_symbol_index_e2e.rs
@@ -1,0 +1,140 @@
+use feeder_service::news::store::NewsStore;
+use feeder_service::news::types::NewsItem;
+use rusqlite::{Connection, params};
+
+fn test_db_path(name: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("valid time")
+        .as_nanos();
+    std::env::temp_dir()
+        .join(format!("feeder-service-{name}-{nanos}.sqlite"))
+        .to_string_lossy()
+        .to_string()
+}
+
+#[test]
+fn backfills_symbol_table_and_prunes_dependent_rows() {
+    let db_path = test_db_path("news-store-symbol-index");
+
+    let conn = Connection::open(&db_path).expect("open sqlite");
+    conn.execute_batch(
+        "
+        CREATE TABLE news_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider TEXT NOT NULL,
+            article_id TEXT NOT NULL,
+            published_at INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            url TEXT NOT NULL,
+            url_hash TEXT NOT NULL,
+            symbols TEXT NOT NULL,
+            sentiment_score REAL,
+            inserted_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+            UNIQUE(provider, article_id),
+            UNIQUE(url_hash)
+        );
+        ",
+    )
+    .expect("create legacy schema");
+
+    conn.execute(
+        "
+        INSERT INTO news_items
+            (provider, article_id, published_at, title, summary, url, url_hash, symbols, sentiment_score)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ",
+        params![
+            "legacy",
+            "article-legacy",
+            1_710_000_000_000_i64,
+            "Legacy BTC article",
+            "Legacy summary",
+            "https://example.com/legacy",
+            "legacy-hash",
+            "[\"btcusdt\",\" BTCUSDT \",\"\",\"ethusdt\"]",
+            0.4_f64,
+        ],
+    )
+    .expect("insert legacy item");
+
+    drop(conn);
+
+    let store = NewsStore::new(db_path.clone());
+    store.init().expect("run migration and backfill");
+
+    let conn = Connection::open(&db_path).expect("open sqlite post-init");
+
+    let index_count: i64 = conn
+        .query_row(
+            "
+            SELECT COUNT(*)
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND name IN (
+                'idx_news_item_symbols_symbol_news_item',
+                'idx_news_item_symbols_symbol_published_at'
+              )
+            ",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count indexes");
+    assert_eq!(index_count, 2);
+
+    let backfilled_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM news_item_symbols WHERE symbol = 'BTCUSDT'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count backfilled symbol rows");
+    assert_eq!(backfilled_count, 1, "symbol rows should be normalized and deduplicated");
+
+    let recent = store
+        .get_recent_by_symbol("BTCUSDT", 1_709_999_999_000, 1_710_000_001_000, 10)
+        .expect("query by symbol");
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].article_id, "article-legacy");
+
+    store
+        .upsert_many(&[NewsItem {
+            id: "article-new".to_string(),
+            source: "new-provider".to_string(),
+            published_at: 1_710_000_000_200,
+            title: "New ETH/BTC article".to_string(),
+            summary: "Something happened".to_string(),
+            url: "https://example.com/new".to_string(),
+            symbols: vec!["btcusdt".to_string(), "ethusdt".to_string()],
+            sentiment_score: Some(0.9),
+        }])
+        .expect("upsert new item");
+
+    let recent_after_upsert = store
+        .get_recent_by_symbol("BTCUSDT", 1_709_999_999_000, 1_710_000_001_000, 10)
+        .expect("query upserted items");
+    assert_eq!(recent_after_upsert.len(), 2);
+    assert_eq!(recent_after_upsert[0].article_id, "article-new");
+
+    let pruned = store
+        .prune_older_than(1_710_000_000_100)
+        .expect("prune old rows");
+    assert_eq!(pruned, 1);
+
+    let legacy_symbol_rows: i64 = conn
+        .query_row(
+            "
+            SELECT COUNT(*)
+            FROM news_item_symbols nis
+            JOIN news_items ni ON ni.id = nis.news_item_id
+            WHERE ni.article_id = 'article-legacy'
+            ",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count symbol rows for pruned item");
+    assert_eq!(legacy_symbol_rows, 0);
+
+    let _ = std::fs::remove_file(db_path);
+}


### PR DESCRIPTION
### Motivation

- Improve performance and accuracy of symbol-based news lookup by avoiding JSON scanning and in-memory filtering.
- Keep symbol tags normalized and deduplicated so correlation queries are deterministic and indexable.
- Ensure schema migrations are safe for existing databases and that retention pruning removes dependent rows consistently.

### Description

- Add a normalized `news_item_symbols(news_item_id, symbol, published_at)` table and two indexes via idempotent statements in `NewsStore::init`, and backfill rows from legacy `news_items.symbols`. 
- Update `upsert_many` to normalize/deduplicate symbols, persist normalized JSON in `news_items`, resolve the `news_item.id`, and upsert corresponding `news_item_symbols` rows in the same transaction. 
- Replace scanned/filtering logic with an indexed join query in `get_recent_by_symbol` that predicates on `symbol` and `published_at` for efficient retrieval. 
- Update `prune_older_than` to delete dependent `news_item_symbols` rows inside the same transaction before deleting stale `news_items`, and add `normalize_symbols`/parsing helpers plus documentation updates. 

### Testing

- Ran `cargo test --test news_store_symbol_index_e2e -- --nocapture` and the end-to-end test passed. 
- Ran `cargo test --test news_correlation_e2e -- --nocapture` and the existing correlation e2e passed. 
- All added tests in `tests/news_store_symbol_index_e2e.rs` passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed3bafda0832d8d1829dda57fe567)