### PR TITLE
Add Telegram notifier fanout with resilient delivery and e2e coverage

### DIFF
--- a/docs/telegram-notifier.md
+++ b/docs/telegram-notifier.md
@@ -1,0 +1,44 @@
+# Telegram notifier
+
+`feeder-service` can fan out enriched signal payloads to both:
+
+- websocket clients (`broadcast::Sender<String>`)
+- Telegram Bot API (`sendMessage`)
+
+The shared formatting path is implemented in `src/notify/mod.rs` so websocket and Telegram consume the same correlation context without duplicating signal assembly logic.
+
+## Environment variables
+
+- `ENABLE_TELEGRAM_NOTIFIER` (`true|false`, default `false`)
+- `TELEGRAM_BOT_TOKEN` (required when enabled)
+- `TELEGRAM_CHAT_ID` (required when enabled)
+- `TELEGRAM_MIN_CORRELATION_SCORE` (default `0.0`)
+- `TELEGRAM_RATE_LIMIT_INTERVAL_SECS` (default `30`)
+- `TELEGRAM_API_BASE_URL` (default `https://api.telegram.org`)
+
+## Message template
+
+Telegram messages are concise and include:
+
+1. symbol + signal type
+2. direction and move magnitude (return %, spike %, or pressure)
+3. correlation score
+4. top matched news headlines with links
+
+Example:
+
+```text
+🔔 BTCUSDT KLINE_QUANT
+BULLISH | move +2.31%
+Correlation score: 0.80
+News:
+• ETF approvals drive demand
+  https://example.com/story
+```
+
+## Delivery behavior
+
+- Websocket publish always happens first.
+- Telegram publish is best-effort and never aborts stream processing.
+- Telegram delivery retries up to 3 attempts with exponential backoff (`300ms`, `600ms`, `1200ms`).
+- If all attempts fail, the system logs the error and continues processing.

--- a/src/bin/refactor.rs
+++ b/src/bin/refactor.rs
@@ -91,7 +91,7 @@ async fn main() {
             // 2) depth updates
             if let Some(depth) = parse_depth_update(payload) {
                 let mut state = app_state.lock().unwrap();
-                state.process_depth_update(&depth, &tx);
+                state.process_depth_update(&depth, &tx).await;
                 continue;
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     /// When `true`, depth streams are not subscribed and depth messages are not processed.
     pub disable_depth_stream: bool,
     pub news: NewsConfig,
+    pub telegram: TelegramConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -29,6 +30,16 @@ pub struct NewsConfig {
     pub retention_hours: i64,
     pub finnhub_api_key: Option<String>,
     pub newsapi_api_key: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TelegramConfig {
+    pub enabled: bool,
+    pub bot_token: Option<String>,
+    pub chat_id: Option<String>,
+    pub min_correlation_score: f64,
+    pub rate_limit_interval_secs: u64,
+    pub api_base_url: String,
 }
 
 impl Config {
@@ -117,6 +128,27 @@ impl Config {
             newsapi_api_key: env::var("NEWSAPI_API_KEY").ok(),
         };
 
+        let telegram = TelegramConfig {
+            enabled: env::var("ENABLE_TELEGRAM_NOTIFIER")
+                .map(|v| {
+                    let value = v.trim().trim_matches('"').trim_matches('\'').to_lowercase();
+                    matches!(value.as_str(), "1" | "true" | "yes")
+                })
+                .unwrap_or(false),
+            bot_token: env::var("TELEGRAM_BOT_TOKEN").ok(),
+            chat_id: env::var("TELEGRAM_CHAT_ID").ok(),
+            min_correlation_score: env::var("TELEGRAM_MIN_CORRELATION_SCORE")
+                .ok()
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or(0.0),
+            rate_limit_interval_secs: env::var("TELEGRAM_RATE_LIMIT_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(30),
+            api_base_url: env::var("TELEGRAM_API_BASE_URL")
+                .unwrap_or_else(|_| "https://api.telegram.org".to_string()),
+        };
+
         Config {
             symbols,
             port,
@@ -126,6 +158,7 @@ impl Config {
             big_depth_min_pressure_pct,
             disable_depth_stream,
             news,
+            telegram,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,5 @@ pub mod time_helpers;
 pub mod ws_helpers;
 
 pub mod news;
+
+pub mod notify;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,13 @@ use feeder_service::news::correlation::CorrelationService;
 use feeder_service::news::providers::fetch_all_news;
 use feeder_service::news::store::NewsStore;
 use feeder_service::news::tagging::tag_symbols;
+use feeder_service::notify::{NotificationFanout, build_signal_notification, telegram::TelegramNotifier};
 use feeder_service::ws_helpers::*;
 use futures_util::StreamExt;
 use local_ip_address::local_ip;
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::time::{Duration, interval};
 use tokio_tungstenite::connect_async;
@@ -63,6 +65,9 @@ async fn main() {
     }
 
     let (tx, _rx) = broadcast::channel(config.broadcast_capacity);
+    let notifier = Arc::new(NotificationFanout::new(Some(TelegramNotifier::new(
+        config.telegram.clone(),
+    ))));
     let correlation_service = NewsStore::new(config.news.db_path.clone());
     let correlation_service = match correlation_service.init() {
         Ok(()) => Some(CorrelationService::from_env(correlation_service)),
@@ -164,6 +169,7 @@ async fn main() {
                     &mut last_prices,
                     &tx,
                     correlation_service.as_ref(),
+                    notifier.as_ref(),
                 )
                 .await;
                 continue;
@@ -179,7 +185,9 @@ async fn main() {
                         &mut big_move_detectors,
                         &tx,
                         correlation_service.as_ref(),
-                    );
+                        notifier.as_ref(),
+                    )
+                    .await;
                     continue;
                 }
             }
@@ -192,7 +200,9 @@ async fn main() {
                         &config_map,
                         &tx,
                         correlation_service.as_ref(),
-                    );
+                        notifier.as_ref(),
+                    )
+                    .await;
                     continue;
                 }
             }
@@ -217,6 +227,7 @@ async fn process_agg_trade(
     last_prices: &mut HashMap<String, f64>,
     tx: &broadcast::Sender<String>,
     correlation_service: Option<&CorrelationService>,
+    notifier: &NotificationFanout,
 ) {
     let symbol = agg.s.to_lowercase();
     let cfg = match config_map.get(&symbol) {
@@ -236,6 +247,7 @@ async fn process_agg_trade(
     build_and_send_enriched_payload(
         tx,
         correlation_service,
+        notifier,
         "agg_trade",
         &symbol,
         agg.t as i64,
@@ -245,16 +257,18 @@ async fn process_agg_trade(
             "spike_pct": spike,
             "buyer_maker": agg.m,
         }),
-    );
+    )
+    .await;
 }
 
-fn process_depth_update(
+async fn process_depth_update(
     depth: &feeder_service::binance_depth::DepthUpdate,
     config_map: &HashMap<String, feeder_service::config::SymbolConfig>,
     config: &Config,
     big_move_detectors: &mut HashMap<String, BigMoveDetector>,
     tx: &broadcast::Sender<String>,
     correlation_service: Option<&CorrelationService>,
+    notifier: &NotificationFanout,
 ) {
     let symbol = depth.symbol.to_lowercase();
     let cfg = match config_map.get(&symbol) {
@@ -363,6 +377,7 @@ fn process_depth_update(
     build_and_send_enriched_payload(
         tx,
         correlation_service,
+        notifier,
         "depth_update",
         &symbol,
         depth.event_time as i64,
@@ -373,7 +388,8 @@ fn process_depth_update(
             "top_bid_count": big_bids.len(),
             "top_ask_count": big_asks.len(),
         }),
-    );
+    )
+    .await;
 
     if let Some(detector) = big_move_detectors.get_mut(&symbol) {
         let snap = DepthSnapshot {
@@ -413,11 +429,12 @@ fn process_depth_update(
     }
 }
 
-fn process_kline_event(
+async fn process_kline_event(
     event: &feeder_service::binance_kline::KlineEvent,
     config_map: &HashMap<String, feeder_service::config::SymbolConfig>,
     tx: &broadcast::Sender<String>,
     correlation_service: Option<&CorrelationService>,
+    notifier: &NotificationFanout,
 ) {
     let symbol = event.symbol.to_lowercase();
     if !config_map.contains_key(&symbol) {
@@ -456,6 +473,7 @@ fn process_kline_event(
         build_and_send_enriched_payload(
             tx,
             correlation_service,
+            notifier,
             "kline_quant",
             &symbol,
             event.event_time as i64,
@@ -466,13 +484,15 @@ fn process_kline_event(
                 "quote_volume": signal.quote_volume,
                 "trade_count": signal.trade_count,
             }),
-        );
+        )
+        .await;
     }
 }
 
-fn build_and_send_enriched_payload(
+async fn build_and_send_enriched_payload(
     tx: &broadcast::Sender<String>,
     correlation_service: Option<&CorrelationService>,
+    notifier: &NotificationFanout,
     signal_type: &str,
     symbol: &str,
     event_timestamp: i64,
@@ -483,17 +503,16 @@ fn build_and_send_enriched_payload(
     };
 
     if let Ok(correlation) = service.correlate(symbol, event_timestamp) {
-        let payload = json!({
-            "signal_type": signal_type,
-            "symbol": symbol.to_uppercase(),
-            "event_timestamp": event_timestamp,
-            "move_metrics": move_metrics,
-            "matched_news": correlation.matches,
-            "correlation_score": correlation.score,
-        })
-        .to_string();
+        let payload = build_signal_notification(
+            signal_type,
+            symbol,
+            event_timestamp,
+            move_metrics,
+            &correlation.matches,
+            correlation.score,
+        );
 
-        let _ = tx.send(payload);
+        notifier.dispatch(tx, payload).await;
     }
 }
 

--- a/src/notify/mod.rs
+++ b/src/notify/mod.rs
@@ -1,0 +1,136 @@
+use serde_json::json;
+use tokio::sync::broadcast;
+
+use crate::news::correlation::MatchedNews;
+
+pub mod telegram;
+
+#[derive(Debug, Clone)]
+pub struct SignalNotification {
+    pub ws_payload: String,
+    pub telegram_message: String,
+    pub correlation_score: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationFanout {
+    telegram: Option<telegram::TelegramNotifier>,
+}
+
+impl NotificationFanout {
+    pub fn new(telegram: Option<telegram::TelegramNotifier>) -> Self {
+        Self { telegram }
+    }
+
+    pub async fn dispatch(
+        &self,
+        tx: &broadcast::Sender<String>,
+        notification: SignalNotification,
+    ) {
+        let _ = tx.send(notification.ws_payload);
+
+        if let Some(telegram) = &self.telegram {
+            telegram
+                .send_with_retry(
+                    &notification.telegram_message,
+                    notification.correlation_score,
+                )
+                .await;
+        }
+    }
+}
+
+pub fn build_signal_notification(
+    signal_type: &str,
+    symbol: &str,
+    event_timestamp: i64,
+    move_metrics: serde_json::Value,
+    matches: &[MatchedNews],
+    correlation_score: f64,
+) -> SignalNotification {
+    let ws_payload = json!({
+        "signal_type": signal_type,
+        "symbol": symbol.to_uppercase(),
+        "event_timestamp": event_timestamp,
+        "move_metrics": move_metrics,
+        "matched_news": matches,
+        "correlation_score": correlation_score,
+    })
+    .to_string();
+
+    let telegram_message = format_telegram_message(
+        signal_type,
+        &symbol.to_uppercase(),
+        &move_metrics,
+        matches,
+        correlation_score,
+    );
+
+    SignalNotification {
+        ws_payload,
+        telegram_message,
+        correlation_score,
+    }
+}
+
+fn format_telegram_message(
+    signal_type: &str,
+    symbol: &str,
+    move_metrics: &serde_json::Value,
+    matches: &[MatchedNews],
+    correlation_score: f64,
+) -> String {
+    let (direction, magnitude) = direction_and_magnitude(move_metrics);
+
+    let mut lines = vec![
+        format!("🔔 {} {}", symbol, signal_type.to_uppercase()),
+        format!("{} | {}", direction, magnitude),
+        format!("Correlation score: {:.2}", correlation_score),
+        "News:".to_string(),
+    ];
+
+    for news in matches.iter().take(3) {
+        lines.push(format!("• {}", news.headline));
+        lines.push(format!("  {}", news.url));
+    }
+
+    if matches.is_empty() {
+        lines.push("• No matched headlines".to_string());
+    }
+
+    lines.join("\n")
+}
+
+fn direction_and_magnitude(move_metrics: &serde_json::Value) -> (String, String) {
+    if let Some(ret) = move_metrics.get("return_pct").and_then(|v| v.as_f64()) {
+        let direction = if ret > 0.0 {
+            "BULLISH"
+        } else if ret < 0.0 {
+            "BEARISH"
+        } else {
+            "FLAT"
+        };
+        return (direction.to_string(), format!("move {:+.2}%", ret));
+    }
+
+    if let Some(spike) = move_metrics.get("spike_pct").and_then(|v| v.as_f64()) {
+        let direction = if spike > 0.0 {
+            "UP"
+        } else if spike < 0.0 {
+            "DOWN"
+        } else {
+            "FLAT"
+        };
+        return (direction.to_string(), format!("spike {:+.2}%", spike));
+    }
+
+    if let Some(pressure) = move_metrics
+        .get("bid_pressure_pct")
+        .and_then(|v| v.as_f64())
+    {
+        let direction = if pressure > 50.0 { "BUY" } else { "SELL" };
+        return (direction.to_string(), format!("bid pressure {:.1}%", pressure));
+    }
+
+    ("N/A".to_string(), "move metrics unavailable".to_string())
+}

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -1,0 +1,127 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde::Serialize;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+use crate::config::TelegramConfig;
+
+#[derive(Debug, Clone)]
+pub struct TelegramNotifier {
+    enabled: bool,
+    bot_token: Option<String>,
+    chat_id: Option<String>,
+    min_correlation_score: f64,
+    rate_limit_interval_secs: u64,
+    api_base_url: String,
+    http: Client,
+    last_sent_at: Arc<Mutex<Option<Instant>>>,
+}
+
+#[derive(Debug, Serialize)]
+struct SendMessageBody<'a> {
+    chat_id: &'a str,
+    text: &'a str,
+    disable_web_page_preview: bool,
+}
+
+impl TelegramNotifier {
+    pub fn new(config: TelegramConfig) -> Self {
+        Self {
+            enabled: config.enabled,
+            bot_token: config.bot_token,
+            chat_id: config.chat_id,
+            min_correlation_score: config.min_correlation_score,
+            rate_limit_interval_secs: config.rate_limit_interval_secs,
+            api_base_url: config.api_base_url,
+            http: Client::builder()
+                .no_proxy()
+                .build()
+                .unwrap_or_else(|_| Client::new()),
+            last_sent_at: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub async fn send_with_retry(&self, message: &str, correlation_score: f64) {
+        if !self.enabled {
+            return;
+        }
+
+        if correlation_score < self.min_correlation_score {
+            return;
+        }
+
+        let Some(bot_token) = self.bot_token.as_deref() else {
+            eprintln!("[notify/telegram] missing TELEGRAM_BOT_TOKEN, skipping notification");
+            return;
+        };
+
+        let Some(chat_id) = self.chat_id.as_deref() else {
+            eprintln!("[notify/telegram] missing TELEGRAM_CHAT_ID, skipping notification");
+            return;
+        };
+
+        self.wait_for_rate_limit().await;
+
+        let url = format!("{}/bot{}/sendMessage", self.api_base_url, bot_token);
+        let body = SendMessageBody {
+            chat_id,
+            text: message,
+            disable_web_page_preview: false,
+        };
+
+        let mut backoff_ms = 300_u64;
+        let mut last_error = None;
+
+        for _ in 0..3 {
+            match self.http.post(&url).json(&body).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    let mut guard = self.last_sent_at.lock().await;
+                    *guard = Some(Instant::now());
+                    return;
+                }
+                Ok(resp) => {
+                    last_error = Some(format!("telegram status {}", resp.status()));
+                }
+                Err(err) => {
+                    last_error = Some(err.to_string());
+                }
+            }
+
+            sleep(Duration::from_millis(backoff_ms)).await;
+            backoff_ms *= 2;
+        }
+
+        if let Some(err) = last_error {
+            eprintln!("[notify/telegram] delivery failed, continuing stream processing: {err}");
+        }
+    }
+
+    async fn wait_for_rate_limit(&self) {
+        if self.rate_limit_interval_secs == 0 {
+            return;
+        }
+
+        let wait_duration = {
+            let guard = self.last_sent_at.lock().await;
+            match *guard {
+                Some(last_sent) => {
+                    let elapsed = last_sent.elapsed();
+                    let min_interval = Duration::from_secs(self.rate_limit_interval_secs);
+                    if elapsed < min_interval {
+                        Some(min_interval - elapsed)
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            }
+        };
+
+        if let Some(wait) = wait_duration {
+            sleep(wait).await;
+        }
+    }
+}

--- a/src/refactor/mod.rs
+++ b/src/refactor/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     binance_kline::{KlineEvent, build_quant_signal_from_kline},
     config::{Config, SymbolConfig},
     news::{correlation::CorrelationService, store::NewsStore},
+    notify::{NotificationFanout, build_signal_notification, telegram::TelegramNotifier},
 };
 
 use self::big_move_detector::{BigMoveDetector, BigMoveSignal, DepthSnapshot};
@@ -29,6 +30,7 @@ pub struct AppState {
     /// Map of symbol to big move detector
     big_move_detectors: HashMap<String, BigMoveDetector>,
     correlation_service: Option<CorrelationService>,
+    notifier: NotificationFanout,
 }
 
 impl AppState {
@@ -53,12 +55,15 @@ impl AppState {
 
         let correlation_service = Self::build_correlation_service(&config).ok();
 
+        let telegram = TelegramNotifier::new(config.telegram.clone());
+
         Self {
             config,
             config_map,
             last_prices: HashMap::new(),
             big_move_detectors,
             correlation_service,
+            notifier: NotificationFanout::new(Some(telegram)),
         }
     }
 
@@ -74,24 +79,21 @@ impl AppState {
         symbol: &str,
         event_ts_ms: i64,
         move_metrics: serde_json::Value,
-    ) -> Option<String> {
+    ) -> Option<crate::notify::SignalNotification> {
         let service = self.correlation_service.as_ref()?;
         let correlation = service.correlate(symbol, event_ts_ms).ok()?;
 
-        Some(
-            json!({
-                "signal_type": signal_type,
-                "symbol": symbol.to_uppercase(),
-                "event_timestamp": event_ts_ms,
-                "move_metrics": move_metrics,
-                "matched_news": correlation.matches,
-                "correlation_score": correlation.score,
-            })
-            .to_string(),
-        )
+        Some(build_signal_notification(
+            signal_type,
+            symbol,
+            event_ts_ms,
+            move_metrics,
+            &correlation.matches,
+            correlation.score,
+        ))
     }
 
-    fn send_enriched_payload(
+    async fn send_enriched_payload(
         &self,
         tx: &broadcast::Sender<String>,
         signal_type: &str,
@@ -102,7 +104,7 @@ impl AppState {
         if let Some(payload) =
             self.build_enriched_payload(signal_type, symbol, event_ts_ms, move_metrics)
         {
-            let _ = tx.send(payload);
+            self.notifier.dispatch(tx, payload).await;
         }
     }
     pub async fn process_agg_trade(&mut self, agg: &AggTrade, tx: &broadcast::Sender<String>) {
@@ -131,10 +133,10 @@ impl AppState {
                 "spike_pct": spike,
                 "buyer_maker": agg.m,
             }),
-        );
+        ).await;
     }
 
-    pub fn process_depth_update(&mut self, depth: &DepthUpdate, tx: &broadcast::Sender<String>) {
+    pub async fn process_depth_update(&mut self, depth: &DepthUpdate, tx: &broadcast::Sender<String>) {
         let symbol = depth.symbol.to_lowercase();
         let cfg = match self.config_map.get(&symbol) {
             Some(c) => c,
@@ -170,6 +172,8 @@ impl AppState {
         println!("{}", depth_msg);
         let _ = tx.send(depth_msg.clone());
 
+
+
         self.send_enriched_payload(
             tx,
             "depth_update",
@@ -182,7 +186,7 @@ impl AppState {
                 "top_bid_count": big_bids.len(),
                 "top_ask_count": big_asks.len(),
             }),
-        );
+        ).await;
 
         self.detect_big_move(&symbol, bid_pressure_pct, total_notional, depth, tx);
     }
@@ -278,7 +282,7 @@ impl AppState {
             top_ask
         )
     }
-    pub fn process_kline_event(&self, event: &KlineEvent, tx: &broadcast::Sender<String>) {
+    pub async fn process_kline_event(&self, event: &KlineEvent, tx: &broadcast::Sender<String>) {
         let symbol = event.symbol.to_lowercase();
         if !self.config_map.contains_key(&symbol) {
             return;
@@ -324,7 +328,7 @@ impl AppState {
                     "quote_volume": signal.quote_volume,
                     "trade_count": signal.trade_count,
                 }),
-            );
+            ).await;
         }
     }
 

--- a/tests/news_correlation_e2e.rs
+++ b/tests/news_correlation_e2e.rs
@@ -1,5 +1,5 @@
 use feeder_service::binance::AggTrade;
-use feeder_service::config::{Config, NewsConfig, SymbolConfig};
+use feeder_service::config::{Config, NewsConfig, SymbolConfig, TelegramConfig};
 use feeder_service::news::store::NewsStore;
 use feeder_service::news::types::NewsItem;
 use feeder_service::refactor::AppState;
@@ -54,6 +54,14 @@ async fn emits_enriched_json_with_news_matches_for_agg_trade() {
             retention_hours: 24,
             finnhub_api_key: None,
             newsapi_api_key: None,
+        },
+        telegram: TelegramConfig {
+            enabled: false,
+            bot_token: None,
+            chat_id: None,
+            min_correlation_score: 0.0,
+            rate_limit_interval_secs: 0,
+            api_base_url: "https://api.telegram.org".to_string(),
         },
     };
 

--- a/tests/quant_vector_4h_e2e.rs
+++ b/tests/quant_vector_4h_e2e.rs
@@ -1,7 +1,7 @@
 use feeder_service::{
     binance_depth::DepthUpdate,
     binance_kline::parse_kline_event,
-    config::{Config, NewsConfig, SymbolConfig},
+    config::{Config, NewsConfig, SymbolConfig, TelegramConfig},
     refactor::AppState,
 };
 use tokio::sync::broadcast;
@@ -39,13 +39,21 @@ async fn quant_vector_uses_closed_4h_kline_and_stays_separate_from_depth() {
             finnhub_api_key: None,
             newsapi_api_key: None,
         },
+        telegram: TelegramConfig {
+            enabled: false,
+            bot_token: None,
+            chat_id: None,
+            min_correlation_score: 0.0,
+            rate_limit_interval_secs: 0,
+            api_base_url: "https://api.telegram.org".to_string(),
+        },
     };
 
     let mut app = AppState::new(config);
     let (tx, mut rx) = broadcast::channel(64);
 
     // Depth activity should not produce QUANT4H messages.
-    app.process_depth_update(&depth("BTCUSDT", 1710000000000, "8.0", "6.0"), &tx);
+    app.process_depth_update(&depth("BTCUSDT", 1710000000000, "8.0", "6.0"), &tx).await;
 
     // Closed 4h kline should produce QUANT4H message.
     let payload = r#"{
@@ -73,7 +81,7 @@ async fn quant_vector_uses_closed_4h_kline_and_stays_separate_from_depth() {
     }"#;
 
     let event = parse_kline_event(payload).expect("expected kline event");
-    app.process_kline_event(&event, &tx);
+    app.process_kline_event(&event, &tx).await;
 
     let mut seen_quant = false;
     while let Ok(msg) = rx.try_recv() {

--- a/tests/quant_vector_4h_open_kline_no_signal_e2e.rs
+++ b/tests/quant_vector_4h_open_kline_no_signal_e2e.rs
@@ -1,6 +1,6 @@
 use feeder_service::{
     binance_kline::parse_kline_event,
-    config::{Config, NewsConfig, SymbolConfig},
+    config::{Config, NewsConfig, SymbolConfig, TelegramConfig},
     refactor::AppState,
 };
 use tokio::sync::broadcast;
@@ -26,6 +26,14 @@ async fn quant_vector_ignores_open_4h_kline_events() {
             retention_hours: 168,
             finnhub_api_key: None,
             newsapi_api_key: None,
+        },
+        telegram: TelegramConfig {
+            enabled: false,
+            bot_token: None,
+            chat_id: None,
+            min_correlation_score: 0.0,
+            rate_limit_interval_secs: 0,
+            api_base_url: "https://api.telegram.org".to_string(),
         },
     };
 
@@ -57,7 +65,7 @@ async fn quant_vector_ignores_open_4h_kline_events() {
     }"#;
 
     let event = parse_kline_event(payload).expect("expected kline event");
-    app.process_kline_event(&event, &tx);
+    app.process_kline_event(&event, &tx).await;
 
     let mut saw_quant = false;
     while let Ok(msg) = rx.try_recv() {

--- a/tests/telegram_notifier_e2e.rs
+++ b/tests/telegram_notifier_e2e.rs
@@ -1,0 +1,114 @@
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use feeder_service::config::TelegramConfig;
+use feeder_service::news::correlation::MatchedNews;
+use feeder_service::notify::{NotificationFanout, build_signal_notification, telegram::TelegramNotifier};
+use serde_json::json;
+use tokio::sync::broadcast;
+use warp::Filter;
+
+#[tokio::test]
+async fn sends_telegram_message_with_compact_template_and_links() {
+    let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let captured_filter = warp::any().map({
+        let captured = captured.clone();
+        move || captured.clone()
+    });
+
+    let route = warp::path!("bottoken123" / "sendMessage")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(captured_filter)
+        .map(
+            |body: serde_json::Value, captured: Arc<Mutex<Vec<String>>>| {
+                let text = body["text"].as_str().unwrap_or_default().to_string();
+                captured.lock().unwrap().push(text);
+                warp::reply::json(&json!({"ok": true}))
+            },
+        );
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    drop(listener);
+
+    let server = tokio::spawn(warp::serve(route).run(addr));
+
+    let notifier = TelegramNotifier::new(TelegramConfig {
+        enabled: true,
+        bot_token: Some("token123".to_string()),
+        chat_id: Some("-100123".to_string()),
+        min_correlation_score: 0.4,
+        rate_limit_interval_secs: 0,
+        api_base_url: format!("http://{}", addr),
+    });
+
+    let fanout = NotificationFanout::new(Some(notifier));
+    let (tx, mut rx) = broadcast::channel(8);
+
+    let notification = build_signal_notification(
+        "kline_quant",
+        "btcusdt",
+        1_710_000_000_000,
+        json!({"return_pct": 2.31}),
+        &[MatchedNews {
+            headline: "ETF approvals drive demand".to_string(),
+            url: "https://example.com/story".to_string(),
+            published_at: 1_710_000_000_100,
+        }],
+        0.8,
+    );
+
+    fanout.dispatch(&tx, notification).await;
+
+    let ws_payload = rx.recv().await.expect("ws payload");
+    assert!(ws_payload.contains("\"signal_type\":\"kline_quant\""));
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let sent = captured.lock().unwrap().clone();
+    assert_eq!(sent.len(), 1);
+    assert!(sent[0].contains("BTCUSDT KLINE_QUANT"));
+    assert!(sent[0].contains("BULLISH | move +2.31%"));
+    assert!(sent[0].contains("ETF approvals drive demand"));
+    assert!(sent[0].contains("https://example.com/story"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn telegram_failures_do_not_interrupt_ws_delivery() {
+    let notifier = TelegramNotifier::new(TelegramConfig {
+        enabled: true,
+        bot_token: Some("token123".to_string()),
+        chat_id: Some("-100123".to_string()),
+        min_correlation_score: 0.0,
+        rate_limit_interval_secs: 0,
+        api_base_url: "http://127.0.0.1:9".to_string(),
+    });
+
+    let fanout = NotificationFanout::new(Some(notifier));
+    let (tx, mut rx) = broadcast::channel(8);
+
+    let notification = build_signal_notification(
+        "agg_trade",
+        "ethusdt",
+        1_710_000_000_000,
+        json!({"spike_pct": -0.67}),
+        &[],
+        0.2,
+    );
+
+    let dispatch = tokio::spawn(async move {
+        fanout.dispatch(&tx, notification).await;
+    });
+
+    let result = tokio::time::timeout(Duration::from_millis(200), rx.recv())
+        .await
+        .expect("ws message should be available quickly")
+        .expect("payload");
+
+    assert!(result.contains("\"signal_type\":\"agg_trade\""));
+
+    dispatch.await.expect("dispatch task complete");
+}


### PR DESCRIPTION
### Motivation

- Provide a unified notification path so enriched signals can be published to websocket clients and optionally to Telegram without duplicating formatting logic.
- Allow operators to enable Telegram delivery with configuration for token/chat, correlation-score gating and rate-limiting while ensuring Telegram delivery never blocks or breaks the websocket stream.
- Keep Telegram delivery resilient (retries/backoff) and degrade to a log-only fallback on failures.

### Description

- Add `TelegramConfig` to `Config` and wire environment variables in `Config::load()` for enable flag, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `TELEGRAM_MIN_CORRELATION_SCORE`, `TELEGRAM_RATE_LIMIT_INTERVAL_SECS`, and `TELEGRAM_API_BASE_URL` (see `src/config.rs`).
- Introduce a notification layer with `src/notify/mod.rs` that builds a single `SignalNotification` (`build_signal_notification`) producing both the websocket JSON payload and the concise Telegram text template, and `NotificationFanout` to dispatch to both targets.
- Implement `TelegramNotifier` in `src/notify/telegram.rs` that uses the Telegram Bot API `sendMessage` with rate-limiting, correlation-score gating, up-to-3 retry attempts with exponential backoff, and a log-only fallback when all attempts fail.
- Integrate the fanout into runtime flows by exporting `notify` in `src/lib.rs`, and updating `src/main.rs` and `src/refactor/mod.rs` to dispatch enriched signals via the fanout (websocket publish first, Telegram best-effort), and update async call sites accordingly.
- Add documentation `docs/telegram-notifier.md` describing env vars, message template, and delivery behaviour, and add end-to-end tests `tests/telegram_notifier_e2e.rs` plus updates to existing e2e fixtures to include the new `TelegramConfig` field.

### Testing

- Ran the full test suite with `cargo test` and all existing unit and e2e tests passed in this environment, including the new `tests/telegram_notifier_e2e.rs` (result: all tests passed).
- Ran the Telegram-specific test invocation `cargo test --test telegram_notifier_e2e` for focused verification and it passed.
- Attempted to run `cargo fmt` but `rustfmt` installation was not available in the environment; formatting is orthogonal to functional tests and can be applied separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aed694ef5c832dbf58e2f30ea43945)