### PR TITLE
Make Telegram notifier optional and fix config edge cases

### DIFF
--- a/docs/telegram-notifier.md
+++ b/docs/telegram-notifier.md
@@ -11,14 +11,18 @@ The shared formatting path is implemented in `src/notify/mod.rs` so websocket an
 
 - `ENABLE_TELEGRAM_NOTIFIER` (`true|false`, default `false`)
 - `TELEGRAM_ENABLED` (`true|false`, default `false`, alias supported for compatibility)
-- `TELEGRAM_BOT_TOKEN` (required when enabled)
-- `TELEGRAM_CHAT_ID` (required when enabled)
+- `TELEGRAM_BOT_TOKEN` (required only when Telegram fanout is enabled)
+- `TELEGRAM_CHAT_ID` (required only when Telegram fanout is enabled)
 - `TELEGRAM_THREAD_ID` (optional forum topic thread id for `sendMessage`)
 - `TELEGRAM_INCLUDE_BIGMOVE` (`true|false`, default `false`)
 - `TELEGRAM_DEBOUNCE_WINDOW_SECS` (default `45`, dedupe window for repeated alerts)
 - `TELEGRAM_MIN_CORRELATION_SCORE` (default `0.0`)
 - `TELEGRAM_RATE_LIMIT_INTERVAL_SECS` (default `30`)
-- `TELEGRAM_API_BASE_URL` (default `https://api.telegram.org`)
+- `TELEGRAM_API_BASE_URL` (default `https://api.telegram.org`; surrounding spaces and trailing `/` are trimmed)
+
+## Optional Telegram behavior
+
+Telegram fanout is treated as **optional**. If `ENABLE_TELEGRAM_NOTIFIER`/`TELEGRAM_ENABLED` is true but credentials are missing, the service logs a warning and continues with websocket-only fanout. This prevents startup/runtime failures in environments where Telegram is intentionally not configured.
 
 ## Message template
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,21 @@ pub struct TelegramConfig {
     pub api_base_url: String,
 }
 
+impl TelegramConfig {
+    /// Returns true when Telegram fanout is enabled and has the required credentials.
+    pub fn is_ready(&self) -> bool {
+        self.enabled
+            && self
+                .bot_token
+                .as_deref()
+                .is_some_and(|v| !v.trim().is_empty())
+            && self
+                .chat_id
+                .as_deref()
+                .is_some_and(|v| !v.trim().is_empty())
+    }
+}
+
 impl Config {
     pub fn load() -> Self {
         let default_qty = env::var("BIG_TRADE_QTY")
@@ -171,7 +186,10 @@ impl Config {
                 .and_then(|v| v.parse::<u64>().ok())
                 .unwrap_or(30),
             api_base_url: env::var("TELEGRAM_API_BASE_URL")
-                .unwrap_or_else(|_| "https://api.telegram.org".to_string()),
+                .map(|v| v.trim().trim_end_matches('/').to_string())
+                .ok()
+                .filter(|v| !v.is_empty())
+                .unwrap_or_else(|| "https://api.telegram.org".to_string()),
         };
 
         Config {
@@ -240,6 +258,45 @@ mod tests {
             std::env::remove_var("DISABLE_DEPTH_STREAM");
             std::env::remove_var("ENABLE_TELEGRAM_NOTIFIER");
             std::env::remove_var("NEWS_STREAMS");
+        }
+    }
+
+    #[test]
+    fn telegram_config_readiness_requires_enabled_and_credentials() {
+        let valid = super::TelegramConfig {
+            enabled: true,
+            bot_token: Some("bot-token".to_string()),
+            chat_id: Some("chat-id".to_string()),
+            ..Default::default()
+        };
+        assert!(valid.is_ready());
+
+        let missing_chat = super::TelegramConfig {
+            chat_id: Some(" ".to_string()),
+            ..valid.clone()
+        };
+        assert!(!missing_chat.is_ready());
+
+        let disabled = super::TelegramConfig {
+            enabled: false,
+            ..valid
+        };
+        assert!(!disabled.is_ready());
+    }
+
+    #[test]
+    fn telegram_api_base_url_is_trimmed() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+
+        unsafe {
+            std::env::set_var("TELEGRAM_API_BASE_URL", " https://api.telegram.org/ ");
+        }
+
+        let config = Config::load();
+        assert_eq!(config.telegram.api_base_url, "https://api.telegram.org");
+
+        unsafe {
+            std::env::remove_var("TELEGRAM_API_BASE_URL");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,9 +74,16 @@ async fn main() {
     }
 
     let (tx, _rx) = broadcast::channel(config.broadcast_capacity);
-    let notifier = Arc::new(NotificationFanout::new(Some(TelegramNotifier::new(
-        config.telegram.clone(),
-    ))));
+    let telegram_notifier = config
+        .telegram
+        .is_ready()
+        .then(|| TelegramNotifier::new(config.telegram.clone()));
+    if config.telegram.enabled && telegram_notifier.is_none() {
+        eprintln!(
+            "[notify/telegram] TELEGRAM enabled but missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID; Telegram fanout disabled"
+        );
+    }
+    let notifier = Arc::new(NotificationFanout::new(telegram_notifier));
     let correlation_service = NewsStore::new(config.news.db_path.clone());
     let correlation_service = match correlation_service.init() {
         Ok(()) => Some(CorrelationService::from_env(correlation_service)),

--- a/src/refactor/mod.rs
+++ b/src/refactor/mod.rs
@@ -55,7 +55,10 @@ impl AppState {
 
         let correlation_service = Self::build_correlation_service(&config).ok();
 
-        let telegram = TelegramNotifier::new(config.telegram.clone());
+        let telegram = config
+            .telegram
+            .is_ready()
+            .then(|| TelegramNotifier::new(config.telegram.clone()));
 
         Self {
             config,
@@ -63,7 +66,7 @@ impl AppState {
             last_prices: HashMap::new(),
             big_move_detectors,
             correlation_service,
-            notifier: NotificationFanout::new(Some(telegram)),
+            notifier: NotificationFanout::new(telegram),
         }
     }
 


### PR DESCRIPTION
### Motivation
- CI runs exposed fragile Telegram wiring and URL parsing that could cause runtime misbehavior when Telegram credentials or config are missing.  
- The project needs deterministic behavior so missing Telegram config does not abort fanout or cause malformed API requests.  
- Improve test coverage and docs to prevent regressions around Telegram rollout flags and API base URL handling.

### Description
- Add `TelegramConfig::is_ready()` to centralize readiness checks for `TELEGRAM` fanout and require both `enabled` and non-empty `bot_token`/`chat_id` for fanout creation.  
- Normalize `TELEGRAM_API_BASE_URL` in `Config::load()` by trimming whitespace and removing trailing `/` to avoid malformed URLs when building `bot{token}` endpoints.  
- Make Telegram notifier creation conditional in the runtime paths (`src/main.rs` and `src/refactor/mod.rs`) so the service continues with websocket-only fanout when Telegram is enabled but credentials are absent, and log a clear warning.  
- Add unit tests for readiness semantics and base URL normalization and update `docs/telegram-notifier.md` to document optional Telegram behavior and API base URL normalization.

### Testing
- Ran `cargo test --all-targets` and all tests passed locally (`31 passed; 0 failed`).  
- Ran targeted new tests `telegram_config_readiness_requires_enabled_and_credentials` and `telegram_api_base_url_is_trimmed` and both passed.  
- Attempted to query GitHub Actions API (`curl` to `api.github.com`) but the environment/proxy returned `403`, so external Actions logs could not be fetched.  
- `cargo fmt --check` and `cargo clippy` were attempted but failed in this environment because the toolchain components (`rustfmt`, `clippy`) are not installed; these should be run in CI or with those components added locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af468c1c00832d9617553429f25b57)