### PR TITLE
Add daily Time Resistance with lunar-adjusted reversal probability and startup log

### DIFF
--- a/docs/time-resistance.md
+++ b/docs/time-resistance.md
@@ -1,0 +1,64 @@
+# Time Resistance (Daily Timeframe)
+
+In your TA naming, **time resistance** is the next daily time boundary where price is more likely
+to react or reverse.
+
+This implementation is lightweight and deterministic:
+- no external API calls
+- O(1) arithmetic only
+- UTC-millisecond input/output
+
+## Daily boundary model
+
+Daily time resistance is the **next daily session rollover**.
+
+You can choose session anchor by UTC offset:
+- `0`  => boundary at `00:00 UTC`
+- `8`  => boundary at `00:00 UTC+8` (`16:00 UTC`)
+- `-5` => boundary at `00:00 UTC-5` (`05:00 UTC`)
+
+## Dynamic astrology logic (non-static)
+
+Time resistance probability is no longer static. It now combines:
+
+1. **Base time proximity score** (near boundary => higher)
+2. **Lunar cycle factor** (astrology component)
+
+### Base time score
+
+`base_prob = max(0, 1 - time_to_boundary / window) * 100`
+
+### Lunar factor
+
+- Uses lunar synodic cycle (`~29.53 days`) from a fixed new-moon epoch.
+- Produces `lunar_factor` in `[0, 1]`.
+- Emphasizes new/full moon reversal tendency with a cosine-based curve.
+
+### Final probability
+
+`reversal_prob = base_prob * (1 - astro_weight) + (lunar_factor * 100) * astro_weight`
+
+- `astro_weight` is clamped to `[0,1]`.
+- `0` => pure time model.
+- `1` => pure lunar astrology model.
+
+## API
+
+- `next_daily_time_resistance_ms(now_ms, session_utc_offset_hours)`
+- `daily_reversal_probability_pct(now_ms, next_boundary_ms, window_minutes)`
+- `lunar_phase_reversal_factor(now_ms)`
+- `astrology_adjusted_reversal_probability_pct(now_ms, next_boundary_ms, window_minutes, astro_weight)`
+- `format_daily_time_resistance_log(now_ms, session_utc_offset_hours, reversal_window_minutes, astro_weight)`
+- `next_time_resistance_ms(now_ms, interval_minutes)`
+
+## Log output
+
+At runtime, service prints one daily time-resistance line on startup:
+
+`[TIME_RESISTANCE][1D] next=<UTC datetime> UTC | session_offset=<+/-hours> | session_time=<local session datetime> | ts_ms=<unix_ms> | reversal_prob=<percent> | base_prob=<percent> | lunar_factor=<0..1> | astro_weight=<0..1> | window=<minutes>m`
+
+## Env vars
+
+- `TIME_RESISTANCE_DAILY_UTC_OFFSET_HOURS` (default: `0`)
+- `TIME_RESISTANCE_REVERSAL_WINDOW_MINUTES` (default: `360`)
+- `TIME_RESISTANCE_ASTRO_WEIGHT` (default: `0.35`)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use feeder_service::notify::{
     NotificationFanout, build_signal_notification, telegram::TelegramNotifier,
 };
 use feeder_service::ws_helpers::*;
+use chrono::Utc;
 use futures_util::StreamExt;
 use local_ip_address::local_ip;
 use serde_json::json;
@@ -23,6 +24,7 @@ use tokio_tungstenite::connect_async;
 use warp::Filter;
 
 use feeder_service::refactor::big_move_detector::{BigMoveDetector, BigMoveSignal, DepthSnapshot};
+use feeder_service::time_helpers::format_daily_time_resistance_log;
 
 #[tokio::main]
 async fn main() {
@@ -151,6 +153,35 @@ async fn main() {
     } else {
         println!(
             "[INFO] Kline quant analysis is inactive (set ENABLE_KLINE_QUANT=true to enable)."
+        );
+    }
+
+    let daily_offset_hours = std::env::var("TIME_RESISTANCE_DAILY_UTC_OFFSET_HOURS")
+        .ok()
+        .and_then(|v| v.parse::<i32>().ok())
+        .unwrap_or(0);
+    let reversal_window_minutes = std::env::var("TIME_RESISTANCE_REVERSAL_WINDOW_MINUTES")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(360);
+    let astro_weight = std::env::var("TIME_RESISTANCE_ASTRO_WEIGHT")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.35);
+    let now_ms = Utc::now().timestamp_millis();
+    if let Some(line) = format_daily_time_resistance_log(
+        now_ms,
+        daily_offset_hours,
+        reversal_window_minutes,
+        astro_weight,
+    ) {
+        println!("{}", line);
+    } else {
+        eprintln!(
+            "[TIME_RESISTANCE][1D] unable to compute boundary | session_offset={:+} | window={}m | astro_weight={:.2}",
+            daily_offset_hours,
+            reversal_window_minutes,
+            astro_weight
         );
     }
 

--- a/src/time_helpers.rs
+++ b/src/time_helpers.rs
@@ -1,6 +1,12 @@
 // File: src/time_helpers.rs
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 
+const MS_PER_MINUTE: i64 = 60_000;
+const MINUTES_PER_DAY: i64 = 1_440;
+const MS_PER_DAY: i64 = 86_400_000;
+const LUNAR_CYCLE_DAYS: f64 = 29.530_588_853;
+const KNOWN_NEW_MOON_MS: i64 = 947_182_440_000; // 2000-01-06 18:14:00 UTC
+
 pub fn utc_to_utc7(ms: i64) -> DateTime<FixedOffset> {
     let utc_ts = Utc.timestamp_millis_opt(ms).unwrap(); // safe unwrap if you trust timestamps
     let offset = FixedOffset::east_opt(7 * 3600).unwrap();
@@ -9,4 +15,240 @@ pub fn utc_to_utc7(ms: i64) -> DateTime<FixedOffset> {
 
 pub fn format_ts(dt: DateTime<FixedOffset>) -> String {
     dt.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+fn next_aligned_boundary_ms(now_ms: i64, interval_minutes: i64) -> Option<i64> {
+    if now_ms < 0 || interval_minutes <= 0 {
+        return None;
+    }
+
+    let interval_ms = interval_minutes.checked_mul(MS_PER_MINUTE)?;
+    let periods_elapsed = now_ms.div_euclid(interval_ms);
+    let next_period = periods_elapsed.checked_add(1)?;
+    next_period.checked_mul(interval_ms)
+}
+
+/// Returns the next UTC timestamp (milliseconds) at which a candle closes for the given
+/// `interval_minutes`.
+pub fn next_time_resistance_ms(now_ms: i64, interval_minutes: i64) -> Option<i64> {
+    next_aligned_boundary_ms(now_ms, interval_minutes)
+}
+
+/// Returns the next daily time-resistance boundary (milliseconds).
+pub fn next_daily_time_resistance_ms(now_ms: i64, session_utc_offset_hours: i32) -> Option<i64> {
+    if now_ms < 0 {
+        return None;
+    }
+
+    let offset_minutes = i64::from(session_utc_offset_hours).checked_mul(60)?;
+    let offset_ms = offset_minutes.checked_mul(MS_PER_MINUTE)?;
+    let interval_ms = MINUTES_PER_DAY.checked_mul(MS_PER_MINUTE)?;
+
+    let shifted = now_ms.checked_add(offset_ms)?;
+    let periods_elapsed = shifted.div_euclid(interval_ms);
+    let next_period = periods_elapsed.checked_add(1)?;
+    next_period.checked_mul(interval_ms)?.checked_sub(offset_ms)
+}
+
+/// Base probability from time distance to boundary.
+pub fn daily_reversal_probability_pct(
+    now_ms: i64,
+    next_boundary_ms: i64,
+    window_minutes: i64,
+) -> Option<f64> {
+    if now_ms < 0 || next_boundary_ms < now_ms || window_minutes <= 0 {
+        return None;
+    }
+
+    let window_ms = window_minutes.checked_mul(MS_PER_MINUTE)?;
+    let time_to_boundary_ms = next_boundary_ms.checked_sub(now_ms)?;
+
+    if time_to_boundary_ms >= window_ms {
+        return Some(0.0);
+    }
+
+    let ratio = 1.0 - (time_to_boundary_ms as f64 / window_ms as f64);
+    Some((ratio * 100.0).clamp(0.0, 100.0))
+}
+
+/// Astrology factor using lunar synodic cycle phase.
+///
+/// Returns value in [0, 1], where 1 means a stronger reversal tendency.
+///
+/// We emphasize New Moon and Full Moon by using `abs(cos(phase * PI))` where
+/// phase is in [0,1) across a lunar cycle.
+pub fn lunar_phase_reversal_factor(now_ms: i64) -> Option<f64> {
+    if now_ms < 0 {
+        return None;
+    }
+
+    let elapsed_days = (now_ms - KNOWN_NEW_MOON_MS) as f64 / MS_PER_DAY as f64;
+    let phase = elapsed_days.rem_euclid(LUNAR_CYCLE_DAYS) / LUNAR_CYCLE_DAYS;
+    let factor = (std::f64::consts::PI * phase).cos().abs();
+    Some(factor.clamp(0.0, 1.0))
+}
+
+/// Dynamic probability = weighted blend of base time score and lunar-phase score.
+///
+/// `astro_weight` is clamped to [0, 1].
+pub fn astrology_adjusted_reversal_probability_pct(
+    now_ms: i64,
+    next_boundary_ms: i64,
+    window_minutes: i64,
+    astro_weight: f64,
+) -> Option<f64> {
+    let base_pct = daily_reversal_probability_pct(now_ms, next_boundary_ms, window_minutes)?;
+    let lunar_pct = lunar_phase_reversal_factor(now_ms)? * 100.0;
+    let w = astro_weight.clamp(0.0, 1.0);
+    Some((base_pct * (1.0 - w) + lunar_pct * w).clamp(0.0, 100.0))
+}
+
+pub fn format_daily_time_resistance_log(
+    now_ms: i64,
+    session_utc_offset_hours: i32,
+    reversal_window_minutes: i64,
+    astro_weight: f64,
+) -> Option<String> {
+    let next_ms = next_daily_time_resistance_ms(now_ms, session_utc_offset_hours)?;
+    let next_utc = Utc.timestamp_millis_opt(next_ms).single()?;
+    let session_offset = FixedOffset::east_opt(session_utc_offset_hours.checked_mul(3600)?)?;
+    let next_session = next_utc.with_timezone(&session_offset);
+
+    let base_prob = daily_reversal_probability_pct(now_ms, next_ms, reversal_window_minutes)?;
+    let lunar_factor = lunar_phase_reversal_factor(now_ms)?;
+    let adjusted_prob = astrology_adjusted_reversal_probability_pct(
+        now_ms,
+        next_ms,
+        reversal_window_minutes,
+        astro_weight,
+    )?;
+
+    Some(format!(
+        "[TIME_RESISTANCE][1D] next={} UTC | session_offset={:+} | session_time={} | ts_ms={} | reversal_prob={:.2}% | base_prob={:.2}% | lunar_factor={:.4} | astro_weight={:.2} | window={}m",
+        next_utc.format("%Y-%m-%d %H:%M:%S"),
+        session_utc_offset_hours,
+        next_session.format("%Y-%m-%d %H:%M:%S %:z"),
+        next_ms,
+        adjusted_prob,
+        base_prob,
+        lunar_factor,
+        astro_weight.clamp(0.0, 1.0),
+        reversal_window_minutes
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        astrology_adjusted_reversal_probability_pct, daily_reversal_probability_pct,
+        format_daily_time_resistance_log, lunar_phase_reversal_factor, next_daily_time_resistance_ms,
+        next_time_resistance_ms,
+    };
+
+    #[test]
+    fn rounds_up_to_next_hour_boundary() {
+        let now_ms = 1_773_234_256_000;
+        let next = next_time_resistance_ms(now_ms, 60).unwrap();
+        assert_eq!(next, 1_773_237_600_000);
+    }
+
+    #[test]
+    fn exact_boundary_moves_to_next_boundary() {
+        let now_ms = 1_773_237_600_000;
+        let next = next_time_resistance_ms(now_ms, 60).unwrap();
+        assert_eq!(next, 1_773_241_200_000);
+    }
+
+    #[test]
+    fn daily_boundary_uses_utc_midnight_when_offset_zero() {
+        let now_ms = 1_773_234_256_000;
+        let next = next_daily_time_resistance_ms(now_ms, 0).unwrap();
+        assert_eq!(next, 1_773_273_600_000);
+    }
+
+    #[test]
+    fn daily_boundary_supports_session_offset() {
+        let now_ms = 1_773_234_256_000;
+        let next = next_daily_time_resistance_ms(now_ms, 8).unwrap();
+        assert_eq!(next, 1_773_244_800_000);
+    }
+
+    #[test]
+    fn reversal_probability_is_zero_far_from_boundary() {
+        let now_ms = 1_773_216_000_000;
+        let next_ms = 1_773_244_800_000;
+        let pct = daily_reversal_probability_pct(now_ms, next_ms, 360).unwrap();
+        assert_eq!(pct, 0.0);
+    }
+
+    #[test]
+    fn reversal_probability_grows_inside_window() {
+        let now_ms = 1_773_234_000_000;
+        let next_ms = 1_773_244_800_000;
+        let pct = daily_reversal_probability_pct(now_ms, next_ms, 360).unwrap();
+        assert_eq!(pct, 50.0);
+    }
+
+    #[test]
+    fn lunar_factor_is_normalized() {
+        let factor = lunar_phase_reversal_factor(1_773_234_256_000).unwrap();
+        assert!((0.0..=1.0).contains(&factor));
+    }
+
+    #[test]
+    fn astrology_adjustment_changes_probability_when_weight_is_nonzero() {
+        let now_ms = 1_773_234_000_000;
+        let next_ms = 1_773_244_800_000;
+        let base = daily_reversal_probability_pct(now_ms, next_ms, 360).unwrap();
+        let adjusted =
+            astrology_adjusted_reversal_probability_pct(now_ms, next_ms, 360, 0.35).unwrap();
+        assert_ne!(base, adjusted);
+    }
+
+    #[test]
+    fn astrology_weight_boundaries_work() {
+        let now_ms = 1_773_234_000_000;
+        let next_ms = 1_773_244_800_000;
+        let base = daily_reversal_probability_pct(now_ms, next_ms, 360).unwrap();
+        let lunar = lunar_phase_reversal_factor(now_ms).unwrap() * 100.0;
+
+        let w0 = astrology_adjusted_reversal_probability_pct(now_ms, next_ms, 360, 0.0).unwrap();
+        let w1 = astrology_adjusted_reversal_probability_pct(now_ms, next_ms, 360, 1.0).unwrap();
+        let w_over =
+            astrology_adjusted_reversal_probability_pct(now_ms, next_ms, 360, 2.0).unwrap();
+
+        assert_eq!(w0, base);
+        assert_eq!(w1, lunar);
+        assert_eq!(w_over, lunar);
+    }
+
+    #[test]
+    fn daily_log_line_includes_astrology_fields() {
+        let now_ms = 1_773_234_256_000;
+        let line = format_daily_time_resistance_log(now_ms, 8, 360, 0.35).unwrap();
+
+        assert!(line.contains("[TIME_RESISTANCE][1D]"));
+        assert!(line.contains("reversal_prob="));
+        assert!(line.contains("base_prob="));
+        assert!(line.contains("lunar_factor="));
+        assert!(line.contains("astro_weight=0.35"));
+        assert!(line.contains("window=360m"));
+    }
+
+    #[test]
+    fn returns_none_for_invalid_inputs() {
+        assert_eq!(next_time_resistance_ms(-1, 60), None);
+        assert_eq!(next_time_resistance_ms(0, 0), None);
+        assert_eq!(next_time_resistance_ms(0, -15), None);
+        assert_eq!(next_daily_time_resistance_ms(-1, 0), None);
+        assert_eq!(daily_reversal_probability_pct(-1, 10, 60), None);
+        assert_eq!(daily_reversal_probability_pct(10, 5, 60), None);
+        assert_eq!(daily_reversal_probability_pct(10, 20, 0), None);
+        assert_eq!(lunar_phase_reversal_factor(-1), None);
+        assert_eq!(
+            astrology_adjusted_reversal_probability_pct(-1, 20, 60, 0.5),
+            None
+        );
+        assert_eq!(format_daily_time_resistance_log(-1, 0, 360, 0.35), None);
+    }
 }


### PR DESCRIPTION
### Motivation

- Introduce a deterministic daily "time resistance" boundary to surface the next daily session rollover and estimate reversal probability. 
- Make the reversal probability dynamic by blending a time-proximity score with a lunar-phase (astrology) factor to capture cyclical tendencies. 
- Emit a single informative startup log line so the service records the next daily boundary and computed probabilities on launch. 

### Description

- Added `src/time_helpers.rs` implementing `next_daily_time_resistance_ms`, `daily_reversal_probability_pct`, `lunar_phase_reversal_factor`, `astrology_adjusted_reversal_probability_pct`, `next_time_resistance_ms`, and `format_daily_time_resistance_log` plus unit tests. 
- Integrated startup logging in `src/main.rs` to read `TIME_RESISTANCE_DAILY_UTC_OFFSET_HOURS`, `TIME_RESISTANCE_REVERSAL_WINDOW_MINUTES`, and `TIME_RESISTANCE_ASTRO_WEIGHT`, compute the next boundary and probability, and print the formatted line via `format_daily_time_resistance_log`. 
- Added documentation `docs/time-resistance.md` describing the model, API, defaults, log format, and behavior. 

### Testing

- Ran unit tests in `src/time_helpers.rs` with `cargo test` which executed boundary calculations, probability math, lunar normalization, input validation, and log formatting tests and they passed. 
- The test suite covers `next_time_resistance_ms`, `next_daily_time_resistance_ms`, `daily_reversal_probability_pct`, `lunar_phase_reversal_factor`, `astrology_adjusted_reversal_probability_pct`, and `format_daily_time_resistance_log` for expected values and invalid inputs. 
- No integration tests were changed as part of this change and the startup logging path was exercised by the added unit tests and invoked on program startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b167c4ddd4832db9d17bd50930f70d)