### PR TITLE
fix: harden agg-trade spike and delay calculations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -17,5 +17,7 @@ It ingests trade streams, detects significant trade events, and distributes them
 
 - **Ingest Data**: Consume trade streams from external sources.
 - **Detect Spikes**: Identify trades exceeding configured thresholds.
+  - Ignore invalid spike baselines (zero/negative/non-finite previous price) to avoid noisy or undefined outputs.
 - **Broadcast Events**: Distribute filtered events to all subscribers.
 - **Log Events**: Maintain records of significant trades for monitoring.
+  - Clamp computed processing delay to non-negative values for clock-skew or future timestamp inputs.

--- a/src/binance.rs
+++ b/src/binance.rs
@@ -20,8 +20,14 @@ pub fn parse_agg_trade(msg: &str) -> Option<AggTrade> {
 
 pub fn calc_spike(last_price: Option<f64>, current: f64) -> f64 {
     last_price
+        .filter(|last| *last > 0.0 && last.is_finite() && current.is_finite())
         .map(|last| ((current - last).abs() / last) * 100.0)
         .unwrap_or(0.0)
+}
+
+fn compute_delay_ms(now_ms: i64, event_ms: u64) -> i64 {
+    let event_ms = event_ms.min(i64::MAX as u64) as i64;
+    now_ms.saturating_sub(event_ms).max(0)
 }
 
 pub async fn log_and_broadcast(
@@ -34,7 +40,7 @@ pub async fn log_and_broadcast(
     let qty: f64 = agg.q.parse().unwrap_or(0.0);
 
     if qty >= cfg.big_trade_qty || spike >= cfg.spike_pct {
-        let delay_ms = Utc::now().timestamp_millis() - agg.t as i64;
+        let delay_ms = compute_delay_ms(Utc::now().timestamp_millis(), agg.t);
 
         let log_msg = format!(
             "[AGG_TRADE] {} - Price: {:.2}, Qty: {:.4}, Spike: {:.4}%, BuyerMaker: {}, Delay: {} ms",

--- a/src/binance_tests.rs
+++ b/src/binance_tests.rs
@@ -22,3 +22,19 @@ fn calc_spike_works_with_previous_price() {
     let spike = calc_spike(Some(100.0), 101.0);
     assert!((spike - 1.0).abs() < f64::EPSILON);
 }
+
+#[test]
+fn calc_spike_is_zero_when_previous_price_is_zero() {
+    assert_eq!(calc_spike(Some(0.0), 101.0), 0.0);
+}
+
+#[test]
+fn calc_spike_is_zero_when_prices_are_non_finite() {
+    assert_eq!(calc_spike(Some(f64::NAN), 101.0), 0.0);
+    assert_eq!(calc_spike(Some(100.0), f64::INFINITY), 0.0);
+}
+
+#[test]
+fn compute_delay_ms_never_goes_negative() {
+    assert_eq!(compute_delay_ms(1_000, 5_000), 0);
+}


### PR DESCRIPTION
### Motivation
- Prevent noisy or undefined spike outputs when previous price is zero/negative/NaN/Inf and avoid negative delay values due to clock skew or future timestamps that caused intermittent CI failures.

### Description
- Hardened `calc_spike` in `src/binance.rs` to ignore invalid baselines by filtering out `<= 0.0` and non-finite values and to require the current price to be finite before computing spike.
- Added `compute_delay_ms(now_ms, event_ms)` helper that clamps computed delay to a non-negative value and replaced direct arithmetic with this helper in `log_and_broadcast`.
- Expanded unit tests in `src/binance_tests.rs` to cover zero baseline, non-finite inputs, and delay clamping using `compute_delay_ms`.
- Updated `SPEC.md` to document the robustness guarantees for spike detection and delay logging.

### Testing
- Ran `cargo test --all-targets`, which completed successfully (all unit tests passed).
- Executed E2E tests `news_correlation_e2e`, `news_price_correlation_e2e`, `news_store_symbol_index_e2e`, `telegram_notifier_e2e`, and `news_telegram_rollout_env_e2e`, all of which passed when run with `--nocapture`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d1caeb9c832db461764fa16ff1d7)