### PR TITLE
Improve news ingest diagnostics and treat whitespace API keys as unset

### DIFF
--- a/docs/news-price-correlation-and-telegram.md
+++ b/docs/news-price-correlation-and-telegram.md
@@ -193,7 +193,8 @@ Symptoms:
 - `matched_news` empty despite obvious related headlines.
 
 Checks:
-1. Confirm `ENABLE_NEWS_INGEST=true` and provider API keys exist.
+1. Confirm `ENABLE_NEWS_INGEST=true` and at least one provider API key exists (`FINNHUB_API_KEY` or `NEWSAPI_API_KEY`).
+   - Keys containing only spaces behave as unset values and will not fetch news.
 2. Verify correlation windows are wide enough (`NEWS_CORRELATION_LOOKBACK_SECS`, `NEWS_CORRELATION_LOOKAHEAD_SECS`).
 3. Confirm symbol tagging contains the traded symbol (`BTC` vs `BTCUSDT` normalization expectations).
 4. Check event/news timestamps are in milliseconds and in expected wall-clock range.

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,8 +156,8 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse::<i64>().ok())
                 .unwrap_or(24 * 7),
-            finnhub_api_key: env::var("FINNHUB_API_KEY").ok(),
-            newsapi_api_key: env::var("NEWSAPI_API_KEY").ok(),
+            finnhub_api_key: Self::load_optional_string("FINNHUB_API_KEY"),
+            newsapi_api_key: Self::load_optional_string("NEWSAPI_API_KEY"),
         };
 
         let telegram = TelegramConfig {
@@ -216,6 +216,13 @@ impl Config {
                 matches!(trimmed.as_str(), "1" | "true" | "yes")
             })
             .unwrap_or(default)
+    }
+
+    fn load_optional_string(key: &str) -> Option<String> {
+        env::var(key)
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
     }
 
     /// Helper: load per-symbol env variable, fallback to default
@@ -285,6 +292,25 @@ mod tests {
             ..valid
         };
         assert!(!disabled.is_ready());
+    }
+
+    #[test]
+    fn news_api_keys_are_trimmed_and_empty_values_are_dropped() {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+
+        unsafe {
+            std::env::set_var("FINNHUB_API_KEY", "  finnhub-token  ");
+            std::env::set_var("NEWSAPI_API_KEY", "   ");
+        }
+
+        let config = Config::load();
+        assert_eq!(config.news.finnhub_api_key.as_deref(), Some("finnhub-token"));
+        assert!(config.news.newsapi_api_key.is_none());
+
+        unsafe {
+            std::env::remove_var("FINNHUB_API_KEY");
+            std::env::remove_var("NEWSAPI_API_KEY");
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -647,6 +647,12 @@ async fn run_news_ingest_loop(news_config: NewsConfig) -> anyhow::Result<()> {
 
     let mut ticker = interval(Duration::from_secs(news_config.poll_interval_secs.max(30)));
 
+    if news_config.finnhub_api_key.is_none() && news_config.newsapi_api_key.is_none() {
+        eprintln!(
+            "[news] no provider API key configured; fetched will stay 0 until FINNHUB_API_KEY or NEWSAPI_API_KEY is set"
+        );
+    }
+
     loop {
         ticker.tick().await;
 


### PR DESCRIPTION
### Motivation

- Operators saw repeating logs like `[news] fetched=0 inserted=0 pruned=0 db=news.sqlite` with no clear reason, commonly caused by ingest being enabled but no usable provider key configured. 
- Whitespace-only env values (e.g. `"   "`) for provider API keys could be considered set and caused confusing behavior. 
- The goal is to provide immediate runtime guidance and make config parsing more robust so empty/whitespace keys are ignored.

### Description

- Emit an explicit runtime warning in the news ingest loop when both `FINNHUB_API_KEY` and `NEWSAPI_API_KEY` are unset so `fetched=0` is easier to interpret (`src/main.rs`).
- Add `load_optional_string` to trim env values and treat empty/whitespace-only strings as `None`, and use it for `FINNHUB_API_KEY` and `NEWSAPI_API_KEY` (`src/config.rs`).
- Add a unit test `news_api_keys_are_trimmed_and_empty_values_are_dropped` to validate trimming and empty-value handling (`src/config.rs` tests).
- Update troubleshooting docs to call out that at least one provider key is required and whitespace-only keys are ignored (`docs/news-price-correlation-and-telegram.md`).

### Testing

- Ran the Rust test suite with `cargo test -q`, and all automated tests passed (unit tests and test suites completed with no failures).
- The added config unit test validating API key trimming and empty handling passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b50855b704832db2950c96160ef4c4)