### PR TITLE
Add self-explanation logs for depth big-move decisions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -21,9 +21,9 @@ It ingests trade streams, detects significant trade events, and distributes them
 - **Broadcast Events**: Distribute filtered events to all subscribers.
 - **Log Events**: Maintain records of significant trades for monitoring.
   - Clamp computed processing delay to non-negative values for clock-skew or future timestamp inputs.
+  - Emit `[BIGMOVE][SELF_EXPLAIN]` decision logs for depth-based breakout detection so operators can trace why a signal fired or was suppressed.
 
 - **Telegram Delivery Behavior**: Telegram fanout is optional and non-blocking.
   - If Telegram is disabled or credentials are missing, stream processing remains active without notifier startup.
   - Delivery failures are logged and must not block websocket fanout or signal processing.
   - CI executes Telegram e2e in skip-safe mode by default, so pipeline success does not require Telegram secrets.
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,7 +499,10 @@ async fn process_depth_update(
             total_notional,
         };
 
-        match detector.push(snap) {
+        let evaluation = detector.push_with_self_explanation(snap);
+        println!("{}", evaluation.self_explanation_log);
+
+        match evaluation.signal {
             BigMoveSignal::BullishBreakout {
                 avg_pressure,
                 total_notional,

--- a/src/refactor/big_move_detector.rs
+++ b/src/refactor/big_move_detector.rs
@@ -22,7 +22,7 @@ pub struct DepthSnapshot {
     pub total_notional: f64,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BigMoveSignal {
     BullishBreakout {
         avg_pressure: f64,
@@ -33,6 +33,12 @@ pub enum BigMoveSignal {
         total_notional: f64,
     },
     None,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct BigMoveEvaluation {
+    pub signal: BigMoveSignal,
+    pub self_explanation_log: String,
 }
 
 impl BigMoveDetector {
@@ -53,13 +59,25 @@ impl BigMoveDetector {
 
     /// Push a new depth snapshot and evaluate.
     pub fn push(&mut self, snapshot: DepthSnapshot) -> BigMoveSignal {
+        self.push_with_self_explanation(snapshot).signal
+    }
+
+    /// Push a new depth snapshot and evaluate with an operator-facing explanation line.
+    pub fn push_with_self_explanation(&mut self, snapshot: DepthSnapshot) -> BigMoveEvaluation {
         if self.window.len() == self.window_size {
             self.window.pop_front();
         }
         self.window.push_back(snapshot);
 
         if self.window.len() < self.min_consecutive {
-            return BigMoveSignal::None;
+            return BigMoveEvaluation {
+                signal: BigMoveSignal::None,
+                self_explanation_log: format!(
+                    "[BIGMOVE][SELF_EXPLAIN] insufficient history ({}/{})",
+                    self.window.len(),
+                    self.min_consecutive
+                ),
+            };
         }
 
         // Check last `min_consecutive` snapshots for consistent extreme pressure
@@ -78,7 +96,14 @@ impl BigMoveDetector {
             .all(|s| (100.0 - s.bid_pressure_pct) >= self.pressure_threshold);
 
         if !all_bullish && !all_bearish {
-            return BigMoveSignal::None;
+            return BigMoveEvaluation {
+                signal: BigMoveSignal::None,
+                self_explanation_log: format!(
+                    "[BIGMOVE][SELF_EXPLAIN] no consistent extreme pressure in last {} snapshots (threshold={:.1}%)",
+                    self.min_consecutive,
+                    self.pressure_threshold
+                ),
+            };
         }
 
         let avg_pressure: f64 =
@@ -87,19 +112,99 @@ impl BigMoveDetector {
             recent.iter().map(|s| s.total_notional).sum::<f64>() / recent.len() as f64;
 
         if avg_notional < self.min_total_notional {
-            return BigMoveSignal::None;
+            return BigMoveEvaluation {
+                signal: BigMoveSignal::None,
+                self_explanation_log: format!(
+                    "[BIGMOVE][SELF_EXPLAIN] pressure extreme but notional too small ({:.0} < {:.0})",
+                    avg_notional,
+                    self.min_total_notional
+                ),
+            };
         }
 
         if all_bullish {
-            BigMoveSignal::BullishBreakout {
-                avg_pressure,
-                total_notional: avg_notional,
+            BigMoveEvaluation {
+                signal: BigMoveSignal::BullishBreakout {
+                    avg_pressure,
+                    total_notional: avg_notional,
+                },
+                self_explanation_log: format!(
+                    "[BIGMOVE][SELF_EXPLAIN] bullish breakout: avg_pressure={:.1}% avg_notional={:.0} threshold={:.1}%",
+                    avg_pressure,
+                    avg_notional,
+                    self.pressure_threshold
+                ),
             }
         } else {
-            BigMoveSignal::BearishBreakout {
-                avg_pressure: 100.0 - avg_pressure,
-                total_notional: avg_notional,
+            let bearish_pressure = 100.0 - avg_pressure;
+            BigMoveEvaluation {
+                signal: BigMoveSignal::BearishBreakout {
+                    avg_pressure: bearish_pressure,
+                    total_notional: avg_notional,
+                },
+                self_explanation_log: format!(
+                    "[BIGMOVE][SELF_EXPLAIN] bearish breakout: avg_pressure={:.1}% avg_notional={:.0} threshold={:.1}%",
+                    bearish_pressure,
+                    avg_notional,
+                    self.pressure_threshold
+                ),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BigMoveDetector, BigMoveSignal, DepthSnapshot};
+
+    #[test]
+    fn self_explanation_reports_insufficient_history() {
+        let mut detector = BigMoveDetector::new(5, 75.0, 0.0, 3);
+        let result = detector.push_with_self_explanation(DepthSnapshot {
+            bid_pressure_pct: 80.0,
+            total_notional: 10_000.0,
+        });
+
+        assert_eq!(result.signal, BigMoveSignal::None);
+        assert!(result.self_explanation_log.contains("insufficient history"));
+    }
+
+    #[test]
+    fn self_explanation_reports_bullish_breakout() {
+        let mut detector = BigMoveDetector::new(5, 75.0, 0.0, 3);
+        for pressure in [80.0, 82.0, 85.0] {
+            let _ = detector.push_with_self_explanation(DepthSnapshot {
+                bid_pressure_pct: pressure,
+                total_notional: 50_000.0,
+            });
+        }
+
+        let result = detector.push_with_self_explanation(DepthSnapshot {
+            bid_pressure_pct: 88.0,
+            total_notional: 50_000.0,
+        });
+
+        assert!(matches!(result.signal, BigMoveSignal::BullishBreakout { .. }));
+        assert!(result.self_explanation_log.contains("bullish breakout"));
+    }
+
+    #[test]
+    fn self_explanation_reports_notional_filter_failure() {
+        let mut detector = BigMoveDetector::new(5, 75.0, 100_000.0, 3);
+        let _ = detector.push_with_self_explanation(DepthSnapshot {
+            bid_pressure_pct: 80.0,
+            total_notional: 1_000.0,
+        });
+        let _ = detector.push_with_self_explanation(DepthSnapshot {
+            bid_pressure_pct: 81.0,
+            total_notional: 1_000.0,
+        });
+        let result = detector.push_with_self_explanation(DepthSnapshot {
+            bid_pressure_pct: 82.0,
+            total_notional: 1_000.0,
+        });
+
+        assert_eq!(result.signal, BigMoveSignal::None);
+        assert!(result.self_explanation_log.contains("notional too small"));
     }
 }

--- a/src/refactor/mod.rs
+++ b/src/refactor/mod.rs
@@ -354,7 +354,10 @@ impl AppState {
                 total_notional,
             };
 
-            match detector.push(snap) {
+            let evaluation = detector.push_with_self_explanation(snap);
+            println!("{}", evaluation.self_explanation_log);
+
+            match evaluation.signal {
                 BigMoveSignal::BullishBreakout {
                     avg_pressure,
                     total_notional,


### PR DESCRIPTION
### Motivation
- Make depth-based breakout decisions auditable by operators by emitting an explicit explanation for each evaluation path so it's easy to trace why a big-move signal fired or was suppressed.
- Preserve existing detector API compatibility while improving observability and test coverage for the breakout logic.

### Description
- Introduce `BigMoveEvaluation` and a new `push_with_self_explanation` method on `BigMoveDetector` that returns both a `BigMoveSignal` and a human-readable `[BIGMOVE][SELF_EXPLAIN]` decision line, while keeping the original `push` delegating to the new API (`src/refactor/big_move_detector.rs`).
- Print the self-explanation line during runtime depth processing in both runtime flows: the main binary path (`src/main.rs`) and the refactored `AppState` flow (`src/refactor/mod.rs`).
- Add three unit tests for the detector to validate explanation messages for insufficient history, bullish breakout, and notional-threshold suppression, and update `SPEC.md` to document operator-facing `[BIGMOVE][SELF_EXPLAIN]` logs.

### Testing
- Ran `cargo test -q` and all tests passed: `50 passed; 0 failed`.
- Attempted `cargo fmt --all` but formatting could not be executed because `rustfmt` is not installed in the environment (warning surfaced).
- Added unit tests in `src/refactor/big_move_detector.rs` which exercise the new `push_with_self_explanation` behavior and they all succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b553bb69b4832db596e27362fa9865)