### PR TITLE
Improve news ingest logs with explicit zero-fetch reasons

### DIFF
--- a/docs/news-price-correlation-and-telegram.md
+++ b/docs/news-price-correlation-and-telegram.md
@@ -210,6 +210,27 @@ Checks:
 3. Check provider responses and auth quotas.
 4. Ensure `NEWS_POLL_INTERVAL_SECS` is not too large for your expectations.
 
+### D) `[news] fetched=0 inserted=0 pruned=0 db=news.sqlite` appears repeatedly
+
+The ingest loop now prints a reason and provider status so operators can immediately see why the counters are zero:
+
+```text
+[news] fetched=0 inserted=0 pruned=0 db=news.sqlite reason=<reason_code> providers=finnhub=<state>;newsapi=<state>
+```
+
+Reason codes:
+- `no_provider_api_key`: both providers are disabled because `FINNHUB_API_KEY` and `NEWSAPI_API_KEY` are unset/empty.
+- `provider_failed`: exactly one provider is configured and its fetch failed.
+- `providers_failed`: both configured providers failed in the current poll cycle.
+- `partial_provider_failure`: one provider failed but another provider succeeded.
+- `providers_returned_no_articles`: providers responded successfully but returned zero rows.
+- `ok`: at least one article was fetched.
+
+Provider states:
+- `disabled`: no API key configured for that provider.
+- `ok`: fetch call succeeded.
+- `failed`: fetch call errored (network/auth/rate-limit/etc.).
+
 ### C) Telegram auth or chat errors
 
 Symptoms:

--- a/src/main.rs
+++ b/src/main.rs
@@ -659,7 +659,7 @@ async fn run_news_ingest_loop(news_config: NewsConfig) -> anyhow::Result<()> {
     loop {
         ticker.tick().await;
 
-        let mut fetched = fetch_all_news(&http, &news_config).await?;
+        let (mut fetched, diagnostics) = fetch_all_news(&http, &news_config).await?;
         for item in &mut fetched {
             tag_symbols(item);
         }
@@ -672,12 +672,16 @@ async fn run_news_ingest_loop(news_config: NewsConfig) -> anyhow::Result<()> {
             chrono::Utc::now().timestamp() - (news_config.retention_hours * 3600);
         let pruned = store.prune_older_than(retention_cutoff)?;
 
+        let reason = diagnostics.fetch_reason(fetched.len());
+
         println!(
-            "[news] fetched={} inserted={} pruned={} db={}",
+            "[news] fetched={} inserted={} pruned={} db={} reason={} providers={}",
             fetched.len(),
             inserted,
             pruned,
-            news_config.db_path
+            news_config.db_path,
+            reason,
+            diagnostics.provider_state_summary(),
         );
     }
 }

--- a/src/news/providers/mod.rs
+++ b/src/news/providers/mod.rs
@@ -3,27 +3,108 @@ use anyhow::Result;
 use reqwest::Client;
 use serde::Deserialize;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderStatus {
+    Disabled,
+    Success,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchDiagnostics {
+    pub finnhub: ProviderStatus,
+    pub newsapi: ProviderStatus,
+}
+
+impl FetchDiagnostics {
+    pub fn all_providers_disabled(&self) -> bool {
+        self.finnhub == ProviderStatus::Disabled && self.newsapi == ProviderStatus::Disabled
+    }
+
+    pub fn failure_summary(&self) -> Option<&'static str> {
+        match (self.finnhub, self.newsapi) {
+            (ProviderStatus::Failed, ProviderStatus::Failed) => {
+                Some("all enabled providers failed")
+            }
+            (ProviderStatus::Failed, ProviderStatus::Disabled)
+            | (ProviderStatus::Disabled, ProviderStatus::Failed) => {
+                Some("the configured provider failed")
+            }
+            (ProviderStatus::Failed, ProviderStatus::Success)
+            | (ProviderStatus::Success, ProviderStatus::Failed) => Some("one provider failed"),
+            _ => None,
+        }
+    }
+
+    pub fn provider_state_summary(&self) -> String {
+        format!(
+            "finnhub={};newsapi={}",
+            self.finnhub.as_label(),
+            self.newsapi.as_label()
+        )
+    }
+
+    pub fn fetch_reason(&self, fetched_count: usize) -> &'static str {
+        if self.all_providers_disabled() {
+            "no_provider_api_key"
+        } else if let Some(summary) = self.failure_summary() {
+            match summary {
+                "all enabled providers failed" => "providers_failed",
+                "the configured provider failed" => "provider_failed",
+                "one provider failed" => "partial_provider_failure",
+                _ => "provider_diagnostic",
+            }
+        } else if fetched_count == 0 {
+            "providers_returned_no_articles"
+        } else {
+            "ok"
+        }
+    }
+}
+
+impl ProviderStatus {
+    fn as_label(self) -> &'static str {
+        match self {
+            ProviderStatus::Disabled => "disabled",
+            ProviderStatus::Success => "ok",
+            ProviderStatus::Failed => "failed",
+        }
+    }
+}
+
 pub async fn fetch_all_news(
     client: &Client,
     config: &crate::config::NewsConfig,
-) -> Result<Vec<NewsItem>> {
+) -> Result<(Vec<NewsItem>, FetchDiagnostics)> {
     let mut items = Vec::new();
+    let mut diagnostics = FetchDiagnostics {
+        finnhub: ProviderStatus::Disabled,
+        newsapi: ProviderStatus::Disabled,
+    };
 
     if let Some(api_key) = config.finnhub_api_key.as_deref() {
+        diagnostics.finnhub = ProviderStatus::Success;
         match fetch_finnhub_news(client, api_key).await {
             Ok(mut provider_items) => items.append(&mut provider_items),
-            Err(err) => eprintln!("[news] finnhub fetch failed: {err}"),
+            Err(err) => {
+                diagnostics.finnhub = ProviderStatus::Failed;
+                eprintln!("[news] finnhub fetch failed: {err}");
+            }
         }
     }
 
     if let Some(api_key) = config.newsapi_api_key.as_deref() {
+        diagnostics.newsapi = ProviderStatus::Success;
         match fetch_newsapi_news(client, api_key).await {
             Ok(mut provider_items) => items.append(&mut provider_items),
-            Err(err) => eprintln!("[news] newsapi fetch failed: {err}"),
+            Err(err) => {
+                diagnostics.newsapi = ProviderStatus::Failed;
+                eprintln!("[news] newsapi fetch failed: {err}");
+            }
         }
     }
 
-    Ok(items)
+    Ok((items, diagnostics))
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,4 +213,67 @@ fn parse_iso8601_timestamp(value: &str) -> Option<i64> {
     chrono::DateTime::parse_from_rfc3339(value)
         .ok()
         .map(|ts| ts.timestamp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FetchDiagnostics, ProviderStatus};
+
+    #[test]
+    fn diagnostics_identify_disabled_providers() {
+        let diagnostics = FetchDiagnostics {
+            finnhub: ProviderStatus::Disabled,
+            newsapi: ProviderStatus::Disabled,
+        };
+
+        assert!(diagnostics.all_providers_disabled());
+        assert_eq!(diagnostics.failure_summary(), None);
+        assert_eq!(
+            diagnostics.provider_state_summary(),
+            "finnhub=disabled;newsapi=disabled"
+        );
+        assert_eq!(diagnostics.fetch_reason(0), "no_provider_api_key");
+    }
+
+    #[test]
+    fn diagnostics_identify_single_provider_failure() {
+        let diagnostics = FetchDiagnostics {
+            finnhub: ProviderStatus::Failed,
+            newsapi: ProviderStatus::Disabled,
+        };
+
+        assert!(!diagnostics.all_providers_disabled());
+        assert_eq!(
+            diagnostics.failure_summary(),
+            Some("the configured provider failed")
+        );
+        assert_eq!(
+            diagnostics.provider_state_summary(),
+            "finnhub=failed;newsapi=disabled"
+        );
+        assert_eq!(diagnostics.fetch_reason(0), "provider_failed");
+    }
+
+    #[test]
+    fn diagnostics_identify_no_articles_case() {
+        let diagnostics = FetchDiagnostics {
+            finnhub: ProviderStatus::Success,
+            newsapi: ProviderStatus::Disabled,
+        };
+
+        assert_eq!(diagnostics.fetch_reason(0), "providers_returned_no_articles");
+        assert_eq!(diagnostics.fetch_reason(2), "ok");
+    }
+
+    #[test]
+    fn diagnostics_identify_partial_failures() {
+        let diagnostics = FetchDiagnostics {
+            finnhub: ProviderStatus::Success,
+            newsapi: ProviderStatus::Failed,
+        };
+
+        assert_eq!(diagnostics.failure_summary(), Some("one provider failed"));
+        assert_eq!(diagnostics.provider_state_summary(), "finnhub=ok;newsapi=failed");
+        assert_eq!(diagnostics.fetch_reason(0), "partial_provider_failure");
+    }
 }


### PR DESCRIPTION
### Motivation
- Operators see repeated `[news] fetched=0 inserted=0 pruned=0 db=news.sqlite` lines with no immediate explanation, making it hard to triage ingest issues quickly.
- The goal is to provide a concise, machine-parseable reason and per-provider state in the ingest log so the root cause (no API keys, provider failures, or empty responses) is obvious.

### Description
- Add `ProviderStatus` and `FetchDiagnostics` types and mapping logic in `src/news/providers/mod.rs` to record per-provider states (`disabled`, `ok`, `failed`) and translate them into a `reason` code. 
- Change `fetch_all_news` to return `(Vec<NewsItem>, FetchDiagnostics)` so callers can include diagnostics alongside fetched items. 
- Update the ingest loop in `src/main.rs` to log `reason=<code>` and `providers=finnhub=<state>;newsapi=<state>` in the `[news] fetched=...` line for immediate visibility. 
- Update documentation `docs/news-price-correlation-and-telegram.md` with the new log format, reason codes, and provider state definitions, and add unit tests in `src/news/providers/mod.rs` to validate diagnostic behaviors.

### Testing
- Ran the unit tests for the modified diagnostics: `cargo test news::providers::tests -- --nocapture`, which completed successfully with `4 passed; 0 failed`.
- A full `cargo test` run was executed (no regressions observed in this environment), and `cargo fmt --all` was attempted but could not run because `rustfmt` is not installed in the current toolchain (environment note only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55afcb51c832d8691d7b4787d9028)