### PR TITLE
Skip news ingest fetch attempts when API keys are absent

### DIFF
--- a/docs/news-price-correlation-and-telegram.md
+++ b/docs/news-price-correlation-and-telegram.md
@@ -218,6 +218,8 @@ The ingest loop now prints a reason and provider status so operators can immedia
 [news] fetched=0 inserted=0 pruned=0 db=news.sqlite reason=<reason_code> providers=finnhub=<state>;newsapi=<state>
 ```
 
+When both provider keys are missing, the loop short-circuits before any HTTP calls and logs `reason=no_provider_api_key` directly.
+
 Reason codes:
 - `no_provider_api_key`: both providers are disabled because `FINNHUB_API_KEY` and `NEWSAPI_API_KEY` are unset/empty.
 - `provider_failed`: exactly one provider is configured and its fetch failed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,12 @@ pub struct NewsConfig {
     pub newsapi_api_key: Option<String>,
 }
 
+impl NewsConfig {
+    pub fn has_provider_api_key(&self) -> bool {
+        self.finnhub_api_key.is_some() || self.newsapi_api_key.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TelegramConfig {
     pub enabled: bool,
@@ -370,5 +376,24 @@ mod tests {
         unsafe {
             std::env::remove_var("TELEGRAM_API_BASE_URL");
         }
+    }
+
+    #[test]
+    fn news_config_reports_when_provider_keys_exist() {
+        let no_keys = super::NewsConfig {
+            enabled: true,
+            db_path: "news.sqlite".to_string(),
+            poll_interval_secs: 300,
+            retention_hours: 24,
+            finnhub_api_key: None,
+            newsapi_api_key: None,
+        };
+        assert!(!no_keys.has_provider_api_key());
+
+        let one_key = super::NewsConfig {
+            finnhub_api_key: Some("token".to_string()),
+            ..no_keys
+        };
+        assert!(one_key.has_provider_api_key());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -763,7 +763,7 @@ async fn run_news_ingest_loop(news_config: NewsConfig) -> anyhow::Result<()> {
 
     let mut ticker = interval(Duration::from_secs(news_config.poll_interval_secs.max(30)));
 
-    if news_config.finnhub_api_key.is_none() && news_config.newsapi_api_key.is_none() {
+    if !news_config.has_provider_api_key() {
         eprintln!(
             "[news] no provider API key configured; fetched will stay 0 until FINNHUB_API_KEY or NEWSAPI_API_KEY is set"
         );
@@ -771,6 +771,14 @@ async fn run_news_ingest_loop(news_config: NewsConfig) -> anyhow::Result<()> {
 
     loop {
         ticker.tick().await;
+
+        if !news_config.has_provider_api_key() {
+            println!(
+                "[news] fetched=0 inserted=0 pruned=0 db={} reason=no_provider_api_key providers=finnhub=disabled;newsapi=disabled",
+                news_config.db_path,
+            );
+            continue;
+        }
 
         let (mut fetched, diagnostics) = fetch_all_news(&http, &news_config).await?;
         for item in &mut fetched {

--- a/src/news/providers/mod.rs
+++ b/src/news/providers/mod.rs
@@ -218,6 +218,7 @@ fn parse_iso8601_timestamp(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::{FetchDiagnostics, ProviderStatus};
+    use crate::config::NewsConfig;
 
     #[test]
     fn diagnostics_identify_disabled_providers() {
@@ -281,5 +282,26 @@ mod tests {
             "finnhub=ok;newsapi=failed"
         );
         assert_eq!(diagnostics.fetch_reason(0), "partial_provider_failure");
+    }
+
+    #[tokio::test]
+    async fn fetch_all_news_skips_network_when_no_api_keys_are_configured() {
+        let client = reqwest::Client::new();
+        let config = NewsConfig {
+            enabled: true,
+            db_path: "news.sqlite".to_string(),
+            poll_interval_secs: 300,
+            retention_hours: 24,
+            finnhub_api_key: None,
+            newsapi_api_key: None,
+        };
+
+        let (items, diagnostics) = super::fetch_all_news(&client, &config)
+            .await
+            .expect("fetch should succeed without network when keys are absent");
+
+        assert!(items.is_empty());
+        assert!(diagnostics.all_providers_disabled());
+        assert_eq!(diagnostics.fetch_reason(items.len()), "no_provider_api_key");
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid unnecessary HTTP calls and network noise when no news provider API keys are configured by short-circuiting the ingest loop.
- Make the zero-fetch diagnostic explicit and immediately observable in logs so operators can distinguish an intentional no-key state from network/provider failures.
- Centralize the API-key presence check to reduce duplication and improve testability.

### Description
- Added `NewsConfig::has_provider_api_key()` to centralize detection of configured provider keys.
- Updated `run_news_ingest_loop` to short-circuit each poll when `has_provider_api_key()` is false, emit the existing zero-fetch diagnostic (`reason=no_provider_api_key`) and `continue` without calling `fetch_all_news`.
- Added a unit test `news_config_reports_when_provider_keys_exist` for the new helper and an async test `fetch_all_news_skips_network_when_no_api_keys_are_configured` to validate `fetch_all_news` behaviour when keys are absent.
- Documented the short-circuit behavior in `docs/news-price-correlation-and-telegram.md` so operators see that the loop skips HTTP calls when both keys are missing.

### Testing
- Ran formatting and tests: `cargo fmt --all` (installed `rustfmt` as needed) and `cargo test`.
- All automated test suites completed successfully, including the new tests (`news_config_reports_when_provider_keys_exist` and `fetch_all_news_skips_network_when_no_api_keys_are_configured`), with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b57179b0b0832d9e416ffa7ff12e59)